### PR TITLE
Move -pie from LDLIBS to LDFLAGS and make LDFLAGS configurable to allow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,12 @@ CFLAGS += -DUSE_PTHREADS
 MON_LDFLAGS += -pthread
 endif
 
-LDFLAGS = -Wl,-z,now,-z,noexecstack
+LDFLAGS ?= -pie -Wl,-z,now,-z,noexecstack
 
 # If you want a static binary, you might uncomment these
 # LDFLAGS += -static
 # STRIP = -s
-LDLIBS = -ldl -pie
+LDLIBS = -ldl
 
 # To explicitly disable libudev, set -DNO_LIBUDEV in CXFLAGS
 ifeq (, $(findstring -DNO_LIBUDEV,  $(CXFLAGS)))


### PR DESCRIPTION
the user to drop it by setting their own LDFLAGS (e.g. PIE could be enabled or disabled by the buildsystem such as buildroot).

Suggested-by: Mariusz Tkaczyk <mariusz.tkaczyk@linux.intel.com>