### PR TITLE
mdadm: Fix compilation for 32-bit arch

### DIFF
--- a/drive_encryption.c
+++ b/drive_encryption.c
@@ -233,7 +233,7 @@ nvme_security_recv_ioctl(int disk_fd, __u8 sec_protocol, __u16 comm_id, void *re
 	nvme_cmd.cdw10 = sec_protocol << 24 | comm_id << 8;
 	nvme_cmd.cdw11 = buf_size;
 	nvme_cmd.data_len = buf_size;
-	nvme_cmd.addr = (__u64)response_buffer;
+	nvme_cmd.addr = (__u64)(uintptr_t)response_buffer;
 
 	status = ioctl(disk_fd, NVME_IOCTL_ADMIN_CMD, &nvme_cmd);
 	if (status != 0) {
@@ -268,7 +268,7 @@ nvme_identify_ioctl(int disk_fd, void *response_buffer, size_t buf_size, const i
 	nvme_cmd.opcode = NVME_IDENTIFY;
 	nvme_cmd.cdw10 = NVME_IDENTIFY_CONTROLLER_DATA;
 	nvme_cmd.data_len = buf_size;
-	nvme_cmd.addr = (__u64)response_buffer;
+	nvme_cmd.addr = (__u64)(uintptr_t)response_buffer;
 
 	status = ioctl(disk_fd, NVME_IOCTL_ADMIN_CMD, &nvme_cmd);
 	if (status != 0) {


### PR DESCRIPTION
Casting void pointer to __u64 works for 64-bit arch but fails to compile on 32-bit arch like i686.

Fail on i686 platform:
drive_encryption.c: In function ‘nvme_security_recv_ioctl’: drive_encryption.c:236:25: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  236 |         nvme_cmd.addr = (__u64)response_buffer;
      |                         ^
drive_encryption.c: In function ‘nvme_identify_ioctl’:
drive_encryption.c:271:25: error: cast from pointer to integer of
different size [-Werror=pointer-to-int-cast]
  271 |         nvme_cmd.addr = (__u64)response_buffer;
      |                         ^
cc1: all warnings being treated as errors
make: *** [Makefile:211: drive_encryption.o] Error 1

This change adds cast void pointer to uintptr_t first to ensure that proper pointer size is used for casting from pointer type. Then is safe to cast it to __u64 because it is tracked as u_int, regardless it is 32-bit or 64-bit arch.

Reported-by: Xiao Ni <xni@redhat.com>
Fixes: cc48406887b3 ("Add reading Opal NVMe encryption information")