### PR TITLE
super-intel fix bad shift

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -2499,11 +2499,11 @@ static int ahci_enumerate_ports(struct sys_dev *hba, int port_count, int host_ba
 	if (dir)
 		closedir(dir);
 	if (err == 0) {
-		int i;
+		int64_t i;
 
 		for (i = 0; i < port_count; i++)
-			if (port_mask & (1 << i))
-				printf("          Port%d : - no device attached -\n", i);
+			if (port_mask & (1LL << i))
+				printf("          Port%ld : - no device attached -\n", i);
 	}
 
 	return err;


### PR DESCRIPTION
In the expression "1 << i", left shifting by more than 31 bits has undefined behavior. The shift amount, "i", is as much as 63. The operand has type "int" (32 bits) and will be shifted as an "int". The fix is to change to a 64 bit int.