### PR TITLE
mdadm.h: provide basename if GLIBC is not avialable

### DIFF
--- a/mdadm.h
+++ b/mdadm.h
@@ -223,6 +223,14 @@ struct dlm_lksb {
 struct __una_u16 { __u16 x; } __attribute__ ((packed));
 struct __una_u32 { __u32 x; } __attribute__ ((packed));
 
+/*
+ * Ensure GNU basename behavior on GLIBC less systems.
+ */
+#ifndef __GLIBC__
+#define basename(path) \
+       (strrchr((path), '/') ? strrchr((path),'/') + 1 : (path))
+#endif
+
 static inline __u16 __get_unaligned16(const void *p)
 {
 	const struct __una_u16 *ptr = (const struct __una_u16 *)p;


### PR DESCRIPTION
If GNU basename is not avilable, define it. It is safer to use that rather than include libgen.h with XPG basename() definition.

Fixes:#12