### PR TITLE
Makefile: fix make -s detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ ifndef UDEVDIR
  UDEVDIR = /lib/udev
 endif
 
-ifeq (,$(findstring s,$(MAKEFLAGS)))
+ifeq (,$(findstring s,$(firstword -$(MAKEFLAGS))))
 	ECHO=echo
 else
 	ECHO=:


### PR DESCRIPTION
Only check the first word of MAKEFLAGS for 's', that's where all the single letter options are collected.

MAKEFLAGS contains _all_ make flags, so if any command line argument contains a letter 's', the silent test will be false positive.  Think e.g. make 'DESTDIR=.../aports/main/mdadm/pkg/mdadm' install