### PR TITLE
mdadm: super-intel remove dead code

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -7046,7 +7046,6 @@ get_devices(const char *hba_path)
 	struct md_list *dv;
 	struct dirent *ent;
 	DIR *dir;
-	int err = 0;
 
 #if DEBUG_LOOP
 	devlist = get_loop_devices();
@@ -7087,14 +7086,6 @@ get_devices(const char *hba_path)
 		dv->devname = xstrdup(buf);
 		dv->next = devlist;
 		devlist = dv;
-	}
-	if (err) {
-		while(devlist) {
-			dv = devlist;
-			devlist = devlist->next;
-			free(dv->devname);
-			free(dv);
-		}
 	}
 	closedir(dir);
 	return devlist;


### PR DESCRIPTION
Execution cannot reach this statement: "while (devlist) { dv = de...". Local variable "err" is assigned only once, to a constant value, making it effectively constant throughout its scope. Remove dead code.