### PR TITLE
test: pass flags to services

### DIFF
--- a/test
+++ b/test
@@ -127,7 +127,7 @@ do_test() {
 				dmesg | grep -iq "error\|call trace\|segfault" | grep -v "systemd" &&
 					die "dmesg prints errors when testing $_basename!"
 			fi
-			echo "succeeded"
+			succeed "succeeded\n"
 			_fail=0
 		else
 			save_log fail
@@ -315,10 +315,8 @@ parse_args() {
 }
 
 print_warning() {
-	cat <<-EOF
-	Warning! Tests are performed on system level mdadm!
-	If you want to test local build, you need to install it first!
-	EOF
+	warn "Warning! Tests are performed on system level mdadm!\n"
+	echo "If you want to test local build, you need to install it first!"
 }
 
 main() {


### PR DESCRIPTION
Commit 4c12714d1ca0 ("test: run tests on system level mdadm") removed MDADM_NO_SYSTEMCTL flag from test suite. This causes imsm tests to fail as mdadm no longer triggers mdmon and flags exists only within session.

Use systemd set/unset-environment to pass necessary flags.

Introduce colors to grab users attention to warnings and key messages.

Make test suite setup systemd environment.
Add setup/clean_systemd_env() functions.
Warn user about altering systemd environment.

Add colors to success/fail messages and warnings.