### PR TITLE
imsm: make freesize required to volume autolayout

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -7749,7 +7749,7 @@ static int validate_geometry_imsm(struct supertype *st, int level, int layout,
 						 verbose))
 			return 0;
 
-		if (super->orom && freesize) {
+		if (super->orom) {
 			int count = count_volumes(super->hba, super->orom->dpa, verbose);
 
 			if (super->orom->vphba <= count) {
@@ -7759,9 +7759,11 @@ static int validate_geometry_imsm(struct supertype *st, int level, int layout,
 			}
 		}
 
-		rv = autolayout_imsm(super, raiddisks, size, *chunk, freesize);
-			if (rv != IMSM_STATUS_OK)
-				return 0;
+		if (freesize) {
+			rv = autolayout_imsm(super, raiddisks, size, *chunk, freesize);
+				if (rv != IMSM_STATUS_OK)
+					return 0;
+		}
 
 		return 1;
 	}


### PR DESCRIPTION
Autolayout_imsm() shall be executed when IMSM_NO_PLATFORM=1 is set. It was fixed by listed commit, checking super->orom was removed, but also checking freesize. Freesize is not set for operations on RAID volume with no size update, that's why it is not required to have this value and always run autolayout_imsm().
Fix it by making autolayout_imsm() dependent on freesize.

Fixes: [46f192](https://github.com/md-raid-utilities/mdadm/commit/46f19270265fe54cda1c728cb156b755273b4ab6) ("imsm: fix first volume autolayout with IMSM_NO_PLATFORM")