### PR TITLE
Revert "mdadm: Fix socket connection failure when mdmon runs in foreground mode."

### DIFF
--- a/msg.c
+++ b/msg.c
@@ -151,7 +151,6 @@ int connect_monitor(char *devname)
 	struct sockaddr_un addr;
 	int pos;
 	char *c;
-	int rv, retry_count = 0;
 
 	pos = sprintf(path, "%s/", MDMON_DIR);
 	if (is_subarray(devname)) {
@@ -171,24 +170,7 @@ int connect_monitor(char *devname)
 
 	addr.sun_family = PF_LOCAL;
 	strcpy(addr.sun_path, path);
-
-	/* In foreground mode, when mdadm is trying to connect to control
-	 * socket it is possible that the mdmon has not created it yet.
-	 * Give some time to mdmon to create socket.
-	 */
-	for (retry_count = 0; retry_count < 10; retry_count++) {
-		rv = connect(sfd, (struct sockaddr*)&addr, sizeof(addr));
-
-		if (rv < 0) {
-			sleep_for(0, MSEC_TO_NSEC(200), true);
-			continue;
-		}
-		break;
-	}
-
-	if (rv < 0) {
-		pr_err("Failed to connect to control socket. (%s!!)\n",
-				strerror(errno));
+	if (connect(sfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		close(sfd);
 		return -1;
 	}


### PR DESCRIPTION
Reverts md-raid-utilities/mdadm#24

@shmsingh I was over optimistic and this change is not ready. The first is that I suggested you to use `for` and I didn't notice that you use `errno` in error message so I gives us following error:
 ``` mdadm: Failed to connect to control socket. (Success!!)  ```
If timeout is reached, errno contains last `usleep()` result.

We can fix that. Not a big deal. There are more critical problem:
It looks like that `ping_monitor()` is called multiple times not as a hard requirement for monitor to be. As a result, the console is frozen for 2 seconds on various commands. This is not acceptable.
For example:
- creation of volume (Looks simple to fix but it is not, `need_mdmon` logic is not complete)
- stopping raids (Manage_stop)
- reshape flows (Grow.c file)
- adding (Manage.c file)
- Incremental (Incremental.c)

Please see how often `ping_monitor()` is used.

Even I disagree that we should call `ping_monitor()` with particularly to chance of success and no error check- well, this is not what code does. Your change is good in the scenarios where `ping_monitor()` is used correctly but overall code is not ready for it. For that reason, I need to revert it.

If you don't want to fix `ping_monitor()` calls case by case, I would like to propose you creation of `connect_monitor_blocking()` or ping_monitor_blocking() and use that to handle cases where it is obviously required to.