### PR TITLE
mdadm: Create.c fix coverity issues

### DIFF
--- a/Create.c
+++ b/Create.c
@@ -297,7 +297,7 @@ static int add_disk_to_super(int mdfd, struct shape *s, struct context *c,
 	if (st->ss->add_to_super(st, &info->disk, fd, dv->devname,
 				 dv->data_offset)) {
 		ioctl(mdfd, STOP_ARRAY, NULL);
-		close(fd);
+		close_fd(&fd);
 		return 1;
 	}
 	st->ss->getinfo_super(st, info, NULL);
@@ -1368,8 +1368,8 @@ int Create(struct supertype *st, struct mddev_ident *ident, int subdevs,
 	map_remove(&map, fd2devnm(mdfd));
 	map_unlock(&map);
 
-	if (mdfd >= 0)
-		close(mdfd);
+	close_fd(&mdfd);
+	close_fd(&container_fd);
 
 	dev_policy_free(custom_pols);
 	return 1;


### PR DESCRIPTION
* Event negative_returns: "fd" is passed to a parameter that cannot be negative. Which is set to -1 to start.

* Event open_fn: Returning handle opened by "open_dev_excl".
* Event var_assign: Assigning: "container_fd" = handle returned from "open_dev_excl(st->container_devnm)"
* Event leaked_handle: Handle variable "container_fd" going out of scope leaks the handle