### PR TITLE
config.c: Fix memory leak in load_containers()

### DIFF
--- a/config.c
+++ b/config.c
@@ -379,6 +379,7 @@ struct mddev_dev *load_containers(void)
 			map = NULL;
 		}
 	free_mdstat(mdstat);
+	map_free(map);
 
 	return rv;
 }


### PR DESCRIPTION
Fix memory leak in load_containers() in config.c reported by SAST analysis.