### PR TITLE
Compiler flags

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,7 +16,7 @@ jobs:
         - name: 'Make with DEBUG flag'
           run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-DEBUG && make clean
         - name: 'Make with DEBIAN flag'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXGALGS=-DEBIAN && make clean
+          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-DEBIAN && make clean
         - name: 'Make with USE_PTHREADS flag'
           run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-USE_PTHREADS && make clean
         - name: 'Make with DNO_LIBUDEV flag'

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 
 # define "CXFLAGS" to give extra flags to CC.
 # e.g.  make CXFLAGS=-O to optimise
-CXFLAGS ?=-O2 -D_FORTIFY_SOURCE=2
+CXFLAGS ?=-O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE
 TCC = tcc
 UCLIBC_GCC = $(shell for nm in i386-uclibc-linux-gcc i386-uclibc-gcc; do which $$nm > /dev/null && { echo $$nm ; exit; } ; done; echo false No uclibc found )
 #DIET_GCC = diet gcc
@@ -73,6 +73,27 @@ ifeq ($(origin STRINGOPOVERFLOW), undefined)
 	STRINGOPOVERFLOW := $(shell $(CC) -Q --help=warnings 2>&1 | grep "stringop-overflow" | wc -l)
 	ifneq "$(STRINGOPOVERFLOW)"  "0"
 	CWFLAGS += -Wstringop-overflow
+	endif
+endif
+
+ifeq ($(origin NOSTRICTOVERFLOW), undefined)
+	NOSTRICTOVERFLOW := $(shell $(CC) -Q --help=warning 2>&1 | grep "strict-overflow" | wc -l)
+	ifneq "$(NOSTRICTOVERFLOW)"  "0"
+	CWFLAGS += -fno-strict-overflow
+	endif
+endif
+
+ifeq ($(origin NODELETENULLPOINTER), undefined)
+	NODELETENULLPOINTER := $(shell $(CC) -Q --help=optimizers 2>&1 | grep "delete-null-pointer-checks" | wc -l)
+	ifneq "$(NODELETENULLPOINTER)"  "0"
+	CWFLAGS += -fno-delete-null-pointer-checks
+	endif
+endif
+
+ifeq ($(origin WRAPV), undefined)
+	WRAPV := $(shell $(CC) -Q --help=optimizers 2>&1 | grep "wrapv" | wc -l)
+	ifneq "$(WRAPV)"  "0"
+	CWFLAGS += -fwrapv
 	endif
 endif
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -2021,6 +2021,9 @@ enum r0layout {
 #define PATH_MAX	4096
 #endif
 
+/* The max string length necessary for decimal conversion, cannot be longer than count of bits */
+#define INT_2_DEC_STR_MAX (sizeof(int) * 8)
+
 #define RESYNC_NONE -1
 #define RESYNC_DELAYED -2
 #define RESYNC_PENDING -3

--- a/super0.c
+++ b/super0.c
@@ -229,7 +229,7 @@ static void examine_super0(struct supertype *st, char *homehost)
 	     d++) {
 		mdp_disk_t *dp;
 		char *dv;
-		char nb[11];
+		char nb[INT_2_DEC_STR_MAX];
 		int wonly, failfast;
 		if (d>=0) dp = &sb->disks[d];
 		else dp = &sb->this_disk;


### PR DESCRIPTION
It is essential to avoid vulnerabilities in code as much
as possible using safe compilation flags. It is easier if
they are added to the Makefile and applied during compilation.
Add new gcc flags and make them configurable, because they
may not be supported for some compilers.
Unset preconfigured FORTIFY_SOURCE, which caused build errors
when built-in flag was used with the same value.
Fix error reported when those additional flags were used.