### PR TITLE
mdstat: Rework mdstat external ararys handling

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -114,14 +114,11 @@ static int is_member_busy(char *metadata_version)
 	int busy = 0;
 
 	for (ent = mdstat; ent; ent = ent->next) {
-		if (ent->metadata_version == NULL)
+		if (!is_mdstat_ent_subarray(ent))
 			continue;
-		if (strncmp(ent->metadata_version, "external:", 9) != 0)
-			continue;
-		if (!is_subarray(&ent->metadata_version[9]))
-			continue;
+
 		/* Skip first char - it can be '/' or '-' */
-		if (strcmp(&ent->metadata_version[10], metadata_version+1) == 0) {
+		if (strcmp(&ent->metadata_version[10], metadata_version + 1) == 0) {
 			busy = 1;
 			break;
 		}

--- a/Manage.c
+++ b/Manage.c
@@ -278,10 +278,8 @@ int Manage_stop(char *devname, int fd, int verbose, int will_retry)
 		 */
 		mds = mdstat_read(0, 0);
 		for (m = mds; m; m = m->next)
-			if (m->metadata_version &&
-			    strncmp(m->metadata_version, "external:", 9)==0 &&
-			    metadata_container_matches(m->metadata_version+9,
-						       devnm)) {
+			if (is_mdstat_ent_external(m) &&
+			    metadata_container_matches(m->metadata_version + 9, devnm)) {
 				if (verbose >= 0)
 					pr_err("Cannot stop container %s: member %s still active\n",
 					       devname, m->devnm);

--- a/Monitor.c
+++ b/Monitor.c
@@ -877,9 +877,7 @@ static int check_array(struct state *st, struct mdstat_ent *mdstat,
 	}
 	last_disk = i;
 
-	if (mse->metadata_version &&
-	    strncmp(mse->metadata_version, "external:", 9) == 0 &&
-	    is_subarray(mse->metadata_version+9)) {
+	if (is_mdstat_ent_subarray(mse)) {
 		char *sl;
 		snprintf(st->parent_devnm, MD_NAME_MAX, "%s", mse->metadata_version + 10);
 		sl = strchr(st->parent_devnm, '/');
@@ -989,13 +987,12 @@ static int add_new_arrays(struct mdstat_ent *mdstat, struct state **statelist)
 			snprintf(st->devnm, MD_NAME_MAX, "%s", mse->devnm);
 			st->percent = RESYNC_UNKNOWN;
 			st->expected_spares = -1;
-			if (mse->metadata_version &&
-			    strncmp(mse->metadata_version,
-				    "external:", 9) == 0 &&
-			    is_subarray(mse->metadata_version+9)) {
+
+			if (is_mdstat_ent_subarray(mse)) {
 				char *sl;
-				snprintf(st->parent_devnm, MD_NAME_MAX,
-					 "%s", mse->metadata_version + 10);
+
+				snprintf(st->parent_devnm, MD_NAME_MAX, "%s",
+					 mse->metadata_version + 10);
 				sl = strchr(st->parent_devnm, '/');
 				*sl = 0;
 			} else
@@ -1294,8 +1291,7 @@ int Wait(char *dev)
 			}
 		}
 		if (!e || e->percent == RESYNC_NONE) {
-			if (e && e->metadata_version &&
-			    strncmp(e->metadata_version, "external:", 9) == 0) {
+			if (e && is_mdstat_ent_external(e)) {
 				if (is_subarray(&e->metadata_version[9]))
 					ping_monitor(&e->metadata_version[9]);
 				else

--- a/config.c
+++ b/config.c
@@ -353,35 +353,38 @@ struct mddev_dev *load_partitions(void)
 struct mddev_dev *load_containers(void)
 {
 	struct mdstat_ent *mdstat = mdstat_read(0, 0);
+	struct mddev_dev *dev_list = NULL;
+	struct map_ent *map_list = NULL;
 	struct mdstat_ent *ent;
-	struct mddev_dev *d;
-	struct mddev_dev *rv = NULL;
-	struct map_ent *map = NULL, *me;
 
-	if (!mdstat)
-		return NULL;
+	for (ent = mdstat; ent; ent = ent->next) {
+		struct mddev_dev *d;
+		struct map_ent *map;
 
-	for (ent = mdstat; ent; ent = ent->next)
-		if (ent->metadata_version &&
-		    strncmp(ent->metadata_version, "external:", 9) == 0 &&
-		    !is_subarray(&ent->metadata_version[9])) {
-			d = xcalloc(1, sizeof(*d));
-			me = map_by_devnm(&map, ent->devnm);
-			if (me)
-				d->devname = xstrdup(me->path);
-			else if (asprintf(&d->devname, "/dev/%s", ent->devnm) < 0) {
-				free(d);
-				continue;
-			}
-			d->next = rv;
-			rv = d;
-			map_free(map);
-			map = NULL;
+		if (!is_mdstat_ent_external(ent))
+			continue;
+
+		if (is_mdstat_ent_subarray(ent))
+			continue;
+
+		d = xcalloc(1, sizeof(*d));
+
+		map = map_by_devnm(&map_list, ent->devnm);
+		if (map) {
+			d->devname = xstrdup(map->path);
+		} else if (asprintf(&d->devname, "/dev/%s", ent->devnm) < 0) {
+			free(d);
+			continue;
 		}
-	free_mdstat(mdstat);
-	map_free(map);
 
-	return rv;
+		d->next = dev_list;
+		dev_list = d;
+	}
+
+	free_mdstat(mdstat);
+	map_free(map_list);
+
+	return dev_list;
 }
 
 struct createinfo createinfo = {

--- a/mapfile.c
+++ b/mapfile.c
@@ -339,18 +339,14 @@ struct map_ent *map_by_name(struct map_ent **map, char *name)
  */
 static char *get_member_info(struct mdstat_ent *ent)
 {
+	char *subarray;
 
-	if (ent->metadata_version == NULL ||
-	    strncmp(ent->metadata_version, "external:", 9) != 0)
+	if (!is_mdstat_ent_subarray(ent))
 		return NULL;
 
-	if (is_subarray(&ent->metadata_version[9])) {
-		char *subarray;
+	subarray = strrchr(ent->metadata_version, '/');
 
-		subarray = strrchr(ent->metadata_version, '/');
-		return subarray + 1;
-	}
-	return NULL;
+	return subarray + 1;
 }
 
 void RebuildMap(void)

--- a/mdadm.h
+++ b/mdadm.h
@@ -743,7 +743,11 @@ extern int mdstat_wait(int seconds);
 extern void mdstat_wait_fd(int fd, const sigset_t *sigmask);
 extern int mddev_busy(char *devnm);
 extern struct mdstat_ent *mdstat_by_component(char *name);
+extern struct mdstat_ent *mdstat_find_by_member_name(struct mdstat_ent *mdstat, char *member_devnm);
 extern struct mdstat_ent *mdstat_by_subdev(char *subdev, char *container);
+
+extern bool is_mdstat_ent_external(struct mdstat_ent *ent);
+extern bool is_mdstat_ent_subarray(struct mdstat_ent *ent);
 
 struct map_ent {
 	struct map_ent *next;
@@ -1771,7 +1775,7 @@ extern int is_mddev(char *dev);
 extern int open_container(int fd);
 extern int metadata_container_matches(char *metadata, char *devnm);
 extern int metadata_subdev_matches(char *metadata, char *devnm);
-extern int is_container_member(struct mdstat_ent *ent, char *devname);
+extern bool is_container_member(struct mdstat_ent *ent, char *devname);
 extern int is_subarray_active(char *subarray, char *devname);
 extern int open_subarray(char *dev, char *subarray, struct supertype *st, int quiet);
 extern struct superswitch *version_to_superswitch(char *vers);

--- a/mdmon.c
+++ b/mdmon.c
@@ -394,9 +394,7 @@ int main(int argc, char *argv[])
 		/* launch an mdmon instance for each container found */
 		mdstat = mdstat_read(0, 0);
 		for (e = mdstat; e; e = e->next) {
-			if (e->metadata_version &&
-			    strncmp(e->metadata_version, "external:", 9) == 0 &&
-			    !is_subarray(&e->metadata_version[9])) {
+			if (is_mdstat_ent_external(e) && !is_mdstat_ent_subarray(e)) {
 				/* update cmdline so this mdmon instance can be
 				 * distinguished from others in a call to ps(1)
 				 */

--- a/mdmon.h
+++ b/mdmon.h
@@ -78,7 +78,7 @@ void do_manager(struct supertype *container);
 extern int sigterm;
 
 int read_dev_state(int fd);
-int is_container_member(struct mdstat_ent *mdstat, char *container);
+bool is_container_member(struct mdstat_ent *mdstat, char *container);
 
 struct mdstat_ent *mdstat_read(int hold, int start);
 

--- a/super-intel.c
+++ b/super-intel.c
@@ -6974,13 +6974,11 @@ active_arrays_by_format(char *name, char* hba, struct md_list **devlist,
 	int found;
 
 	for (memb = mdstat ; memb ; memb = memb->next) {
-		if (memb->metadata_version &&
-		    (strncmp(memb->metadata_version, "external:", 9) == 0) &&
-		    (strcmp(&memb->metadata_version[9], name) == 0) &&
-		    !is_subarray(memb->metadata_version+9) &&
-		    memb->members) {
+		if (is_mdstat_ent_external(memb) && !is_subarray(memb->metadata_version + 9) &&
+		    strcmp(&memb->metadata_version[9], name) == 0 && memb->members) {
 			struct dev_member *dev = memb->members;
 			int fd = -1;
+
 			while (dev && !is_fd_valid(fd)) {
 				char *path = xmalloc(strlen(dev->name) + strlen("/dev/") + 1);
 				num = snprintf(path, PATH_MAX, "%s%s", "/dev/", dev->name);
@@ -6998,7 +6996,6 @@ active_arrays_by_format(char *name, char* hba, struct md_list **devlist,
 				struct mdstat_ent *vol;
 				for (vol = mdstat ; vol ; vol = vol->next) {
 					if (vol->active > 0 &&
-					    vol->metadata_version &&
 					    is_container_member(vol, memb->devnm)) {
 						found++;
 						count++;

--- a/util.c
+++ b/util.c
@@ -1671,16 +1671,6 @@ int metadata_subdev_matches(char *metadata, char *devnm)
 	return 0;
 }
 
-int is_container_member(struct mdstat_ent *mdstat, char *container)
-{
-	if (mdstat->metadata_version == NULL ||
-	    strncmp(mdstat->metadata_version, "external:", 9) != 0 ||
-	    !metadata_container_matches(mdstat->metadata_version+9, container))
-		return 0;
-
-	return 1;
-}
-
 int is_subarray_active(char *subarray, char *container)
 {
 	struct mdstat_ent *mdstat = mdstat_read(0, 0);


### PR DESCRIPTION
To avoid repeating `mdstat_read()` in `IncrementalRemove()`, new function `mdstat_find_by_member_name()` has been proposed. With that, `IncrementalRemove()` handles own copy of mdstat content and there is no need to repeat reading for external stop.

Additionally, It proposed few helper to avoid repeating `ent->metadata_version` checks across code.

Tested by:
- `mdadm -If nvme0n1` - This involves testing `mdstat_find_by_member_name()`
- `mdadm -G -l0 /dev/md126` - This involves `mdadm_by_subdev()`