### PR TITLE
mdadm managemon.c fix coverity issues

### DIFF
--- a/managemon.c
+++ b/managemon.c
@@ -776,10 +776,8 @@ static void manage_new(struct mdstat_ent *mdstat,
 
 error:
 	pr_err("failed to monitor %s\n", mdstat->metadata_version);
-	if (new) {
-		new->container = NULL;
-		free_aa(new);
-	}
+	new->container = NULL;
+	free_aa(new);
 	if (mdi)
 		sysfs_free(mdi);
 }
@@ -870,8 +868,15 @@ void read_sock(struct supertype *container)
 		return;
 
 	fl = fcntl(fd, F_GETFL, 0);
+	if (fl < 0) {
+		close_fd(&fd);
+		return;
+	}
 	fl |= O_NONBLOCK;
-	fcntl(fd, F_SETFL, fl);
+	if (fcntl(fd, F_SETFL, fl) < 0) {
+		close_fd(&fd);
+		return;
+	}
 
 	do {
 		msg.buf = NULL;


### PR DESCRIPTION
Fixing the following coding errors the coverity tools found:

* Event check_return: Calling "fcntl(fd, 4, fl)" without checking return value. This library function may fail and return an error code.

* Event check_after_deref: Null-checking "new" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.