### PR TITLE
imsm: add indent for encryption details

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -2318,7 +2318,7 @@ void print_encryption_information(int disk_fd, enum sys_dev_type hba_type)
 {
 	struct encryption_information information = {0};
 	mdadm_status_t status = MDADM_STATUS_SUCCESS;
-	const char *indent = "                  ";
+	const char *indent = "                    ";
 
 	switch (hba_type) {
 	case SYS_DEV_VMD:


### PR DESCRIPTION
Improve readability of the output. Result after change from `mdadm --detail-platform`
```
 I/O Controller : /sys/devices/pci0000:17/0000:17:05.5 (VMD)
 NVMe under VMD : /dev/nvme3n1 (PHLF737200841P0GGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme6n1 (PHLJ915002N81P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme2n1 (PHLJ915000811P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme5n1 (PHLJ914600DV1P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme4n1 (PHLJ915003221P0FGN)
                    Encryption(Ability|Status): None|Unencrypted

```

