### PR TITLE
mdadm: msg.c fix coverity issues

### DIFF
--- a/msg.c
+++ b/msg.c
@@ -176,8 +176,15 @@ int connect_monitor(char *devname)
 	}
 
 	fl = fcntl(sfd, F_GETFL, 0);
+	if (fl < 0) {
+		close(sfd);
+		return -1;
+	}
 	fl |= O_NONBLOCK;
-	fcntl(sfd, F_SETFL, fl);
+	if (fcntl(sfd, F_SETFL, fl) < 0) {
+		close(sfd);
+		return -1;
+	}
 
 	return sfd;
 }


### PR DESCRIPTION
Fixing the following coding errors the coverity tools found:

* Event check_return: Calling "fcntl(sfd, 4, fl)" without checking return value. This library function may fail and return an error code.