### PR TITLE
mdadm: sysfs.c fix coverity issues

### DIFF
--- a/sysfs.c
+++ b/sysfs.c
@@ -139,7 +139,7 @@ int sysfs_init(struct mdinfo *mdi, int fd, char *devnm)
 		goto out;
 	if (!S_ISDIR(stb.st_mode))
 		goto out;
-	strcpy(mdi->sys_name, devnm);
+	strncpy(mdi->sys_name, devnm, sizeof(mdi->sys_name) - 1);
 
 	retval = 0;
 out:
@@ -179,6 +179,7 @@ struct mdinfo *sysfs_read(int fd, char *devnm, unsigned long options)
 			sra->array.major_version = -1;
 			sra->array.minor_version = -2;
 			strcpy(sra->text_version, buf+9);
+			sra->text_version[sizeof(sra->text_version) - 1] = '\0';
 		} else {
 			sscanf(buf, "%d.%d",
 			       &sra->array.major_version,
@@ -340,6 +341,7 @@ struct mdinfo *sysfs_read(int fd, char *devnm, unsigned long options)
 
 		}
 		strcpy(dev->sys_name, de->d_name);
+		dev->sys_name[sizeof(dev->sys_name) - 1] = '\0';
 		dev->disk.raid_disk = strtoul(buf, &ep, 10);
 		if (*ep) dev->disk.raid_disk = -1;
 


### PR DESCRIPTION
Fixing the following coding errors the coverity tools found:

* Event fixed_size_dest: You might overrun the 32-character fixed-size string "mdi->sys_name" by copying "devnm" without checking the length

* Event fixed_size_dest: You might overrun the 50-character fixed-size string "sra->text_version" by copying "buf + 9" without checking the length.

* Event string_overflow: You might overrun the 32-character destination string "dev->sys_name" by writing 256 characters from "de->d_name".