### PR TITLE
Detail: fix --detail --export for uuid_zero

### DIFF
--- a/Detail.c
+++ b/Detail.c
@@ -274,7 +274,7 @@ int Detail(char *dev, struct context *c)
 				       array.minor_version);
 		}
 
-		if (info)
+		if (info && memcmp(info->uuid, uuid_zero, sizeof(int[4])) != 0)
 			mp = map_by_uuid(&map, info->uuid);
 		if (!mp)
 			mp = map_by_devnm(&map, fd2devnm(fd));


### PR DESCRIPTION
Mentioned commit (see Fixes) causes that devices with UUID equal to uuid_zero was not recognized properly. For few devices the first one was taken always, and the same information was printed. It caused regression, when few containers were created, symlinks were generated only for the first one.

Add checking if uuid is uuid_zero and, if yes, use devname to differentiate devices.

Fixes: 60c19530dd7c ("Detail: remove duplicated code")