### PR TITLE
mdmon: delegate removal to managemon

### DIFF
--- a/managemon.c
+++ b/managemon.c
@@ -440,6 +440,39 @@ static int disk_init_and_add(struct mdinfo *disk, struct mdinfo *clone,
 	return 0;
 }
 
+/**
+ * managemon_disk_remove()- remove disk from the MD array.
+ * @disk: device to be removed.
+ * @array_devnm: the name of the array to remove disk from.
+ *
+ * It tries to remove the disk from the MD array and if it is successful then it closes all opened
+ * descriptors. Removing action requires suspend, it might take a while.
+ * Invalidating mdi->state_fd will prevent from using this device further (see duplicate_aa()).
+ *
+ * To avoid deadlock, new file descriptor is opened because monitor may already wait on
+ * mdddev_suspend() in kernel and keep saved descriptor locked.
+ *
+ * Returns MDADM_STATUS_SUCCESS if disk has been removed, MDADM_STATUS_ERROR otherwise.
+ */
+static mdadm_status_t managemon_disk_remove(struct mdinfo *disk, char *array_devnm)
+{
+	int new_state_fd = sysfs_open2(array_devnm, disk->sys_name, "state");
+
+	if (!is_fd_valid(new_state_fd))
+		return MDADM_STATUS_ERROR;
+
+	if (write_attr("remove", new_state_fd) != MDADM_STATUS_SUCCESS)
+		return MDADM_STATUS_ERROR;
+
+	close_fd(&new_state_fd);
+	close_fd(&disk->state_fd);
+	close_fd(&disk->recovery_fd);
+	close_fd(&disk->bb_fd);
+	close_fd(&disk->ubb_fd);
+
+	return MDADM_STATUS_SUCCESS;
+}
+
 static void manage_member(struct mdstat_ent *mdstat,
 			  struct active_array *a)
 {
@@ -518,6 +551,43 @@ static void manage_member(struct mdstat_ent *mdstat,
 		if (write_attr("0.001", a->safe_mode_delay_fd) == MDADM_STATUS_SUCCESS)
 			a->info.safe_mode_delay = 1;
 
+	if (a->check_member_remove) {
+		bool any_removed = false;
+		bool all_removed = true;
+		struct mdinfo *disk;
+
+		for (disk = a->info.devs; disk; disk = disk->next) {
+			if (disk->man_disk_to_remove == false)
+				continue;
+
+			if (disk->mon_descriptors_not_used == false) {
+				/* To early, repeat later */
+				all_removed = false;
+				continue;
+			}
+
+			if (managemon_disk_remove(disk, a->info.sys_name)) {
+				all_removed = false;
+				continue;
+			}
+
+			any_removed = true;
+		}
+
+		if (any_removed) {
+			struct active_array *newa = duplicate_aa(a);
+
+			if (all_removed)
+				newa->check_member_remove = false;
+
+			replace_array(container, a, newa);
+			a = newa;
+		}
+
+		if (!all_removed)
+			return;
+	}
+
 	/* We don't check the array while any update is pending, as it
 	 * might container a change (such as a spare assignment) which
 	 * could affect our decisions.
@@ -539,8 +609,6 @@ static void manage_member(struct mdstat_ent *mdstat,
 			return;
 
 		newa = duplicate_aa(a);
-		if (!newa)
-			goto out;
 		/* prevent the kernel from activating the disk(s) before we
 		 * finish adding them
 		 */
@@ -570,7 +638,7 @@ static void manage_member(struct mdstat_ent *mdstat,
 				  "sync_action", "recover") == 0)
 			newa->prev_action = recover;
 		dprintf("recovery started on %s\n", a->info.sys_name);
- out:
+
 		while (newdev) {
 			d = newdev->next;
 			free(newdev);
@@ -604,11 +672,9 @@ static void manage_member(struct mdstat_ent *mdstat,
 			if (d2)
 				/* already have this one */
 				continue;
-			if (!newa) {
+			if (!newa)
 				newa = duplicate_aa(a);
-				if (!newa)
-					break;
-			}
+
 			newd = xmalloc(sizeof(*newd));
 			disk_init_and_add(newd, d, newa);
 		}

--- a/mdadm.h
+++ b/mdadm.h
@@ -416,6 +416,12 @@ struct mdinfo {
 	#define	DS_EXTERNAL_BB	4096
 	int prev_state, curr_state, next_state;
 
+	/* If set by monitor, managemon needs to remove faulty device */
+	bool man_disk_to_remove : 1;
+
+	/* Managemon cannot close descriptors if monitor is using them for select() */
+	bool mon_descriptors_not_used : 1;
+
 	/* info read from sysfs */
 	enum {
 		ARRAY_CLEAR,

--- a/mdadm.h
+++ b/mdadm.h
@@ -413,6 +413,7 @@ struct mdinfo {
 	#define DS_BLOCKED	16
 	#define	DS_REMOVE	1024
 	#define	DS_UNBLOCK	2048
+	#define	DS_EXTERNAL_BB	4096
 	int prev_state, curr_state, next_state;
 
 	/* info read from sysfs */

--- a/mdmon.h
+++ b/mdmon.h
@@ -48,8 +48,14 @@ struct active_array {
 	enum array_state prev_state, curr_state, next_state;
 	enum sync_action prev_action, curr_action, next_action;
 
-	int check_degraded; /* flag set by mon, read by manage */
-	int check_reshape; /* flag set by mon, read by manage */
+	bool check_degraded : 1; /* flag set by mon, read by manage */
+	bool check_reshape : 1; /* flag set by mon, read by manage */
+
+	/**
+	 * Signalize managemon there is a mdi to be removed.
+	 * Monitor must acknowledge faulty state first.
+	 */
+	bool check_member_remove : 1;
 };
 
 /*

--- a/monitor.c
+++ b/monitor.c
@@ -150,6 +150,8 @@ int read_dev_state(int fd)
 			rv |= DS_SPARE;
 		if (sysfs_attr_match(cp, "blocked"))
 			rv |= DS_BLOCKED;
+		if (sysfs_attr_match(cp, "external_bbl"))
+			rv |= DS_EXTERNAL_BB;
 		cp = strchr(cp, ',');
 		if (cp)
 			cp++;
@@ -306,9 +308,6 @@ static int check_for_cleared_bb(struct active_array *a, struct mdinfo *mdi)
 	struct md_bb *bb;
 	int i;
 
-	if (!ss->get_bad_blocks)
-		return -1;
-
 	/*
 	 * Get a list of bad blocks for an array, then read list of
 	 * acknowledged bad blocks from kernel and compare it against metadata
@@ -397,7 +396,7 @@ static void signal_manager(void)
 
 #define ARRAY_DIRTY 1
 #define ARRAY_BUSY 2
-static int read_and_act(struct active_array *a, fd_set *fds)
+static int read_and_act(struct active_array *a)
 {
 	unsigned long long sync_completed;
 	int check_degraded = 0;
@@ -425,23 +424,32 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 	for (mdi = a->info.devs; mdi ; mdi = mdi->next) {
 		mdi->next_state = 0;
 		mdi->curr_state = 0;
-		if (mdi->state_fd >= 0) {
-			read_resync_start(mdi->recovery_fd,
-					  &mdi->recovery_start);
-			mdi->curr_state = read_dev_state(mdi->state_fd);
-		}
-		/*
-		 * If array is blocked and metadata handler is able to handle
-		 * BB, check if you can acknowledge them to md driver. If
-		 * successful, clear faulty state and unblock the array.
-		 */
-		if ((mdi->curr_state & DS_BLOCKED) &&
-		    a->container->ss->record_bad_block &&
-		    (process_dev_ubb(a, mdi) > 0)) {
+
+		if (!is_fd_valid(mdi->state_fd))
+			/* We are removing this device, skip it then */
+			continue;
+
+		read_resync_start(mdi->recovery_fd, &mdi->recovery_start);
+		mdi->curr_state = read_dev_state(mdi->state_fd);
+
+		if (!(mdi->curr_state & DS_EXTERNAL_BB))
+			/*
+			 * It assumes that superswitch badblock functions are set if disk
+			 * has external badblocks support configured.
+			 */
+			continue;
+
+		if ((mdi->curr_state & DS_BLOCKED) && process_dev_ubb(a, mdi) > 0)
+			/*
+			 * Blocked has two meanings: we need to acknowledge failure or badblocks
+			 * (if supported). Here, badblocks are handled.
+			 *
+			 * If successful, unblock the array. This is not perfect but
+			 * process_dev_ubb() may disable badblock support in case of failure.
+			 */
 			mdi->next_state |= DS_UNBLOCK;
-		}
-		if (FD_ISSET(mdi->bb_fd, fds))
-			check_for_cleared_bb(a, mdi);
+
+		check_for_cleared_bb(a, mdi);
 	}
 
 	gettimeofday(&tv, NULL);
@@ -855,7 +863,8 @@ static int wait_and_act(struct supertype *container, int nowait)
 			signal_manager();
 		}
 		if (a->container && !a->to_remove) {
-			int ret = read_and_act(a, &rfds);
+			int ret = read_and_act(a);
+
 			rv |= 1;
 			dirty_arrays += !!(ret & ARRAY_DIRTY);
 			/* when terminating stop manipulating the array after it


### PR DESCRIPTION
Starting from [1], kernel requires suspend lock on member drive remove path. It causes deadlock with external management because monitor thread may be locked on suspend and is unable to switch array to active, for example if badblock is reported in this time.

It is blocking action now, so it must be delegated to managemon thread but we must ensure that monitor does metadata update first, just after detecting faulty.

This patch adds appropriative support. Monitor thread detects "faulty", and updates the metadata. After that it is asking manager thread to remove the device.

Manager should not activate recovery for the device if it is not able to remove all devices marked to remove.

Because it is blocking action in kernel now, looks like that retries are no longer required. There is no special short delay in case of remove failure as it was in monitor.

[1] kernel commit cfa078c8b80d ("md: use new apis to suspend array for adding/removing rdev from state_store()")