### PR TITLE
Fix compilation error for gcc14

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,25 +4,29 @@ env:
   cflags: -Werror
 jobs:
   make:
-    runs-on: ubuntu-latest
+    # when gcc is not found, it may be needed to update runner version
+    runs-on: ubuntu-24.04
     name: Compilation test with gcc
     strategy:
       matrix:
-        gcc-version: [7, 8, 9, 10, 11, 12, 13]
+        # gcc-versions are used to test up to 5 years old
+        gcc-version: [9, 10, 11, 12, 13, 14]
     steps:
         - uses: actions/checkout@v4
         - name: 'Add ubuntu repository and install dependencies'
           run: .github/tools/install_ubuntu_packages.sh ${{ matrix.gcc-version }}
+        - name: 'Check if gcc was installed correctly'
+          run: gcc-${{ matrix.gcc-version }} --version
         - name: 'Make with DEBUG flag'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-DEBUG && make clean
+          run: V=1 make -j$(nproc) -B CC=gcc-${{ matrix.gcc-version }} CXFLAGS=-DEBUG && make clean
         - name: 'Make with DEBIAN flag'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-DEBIAN && make clean
+          run: V=1 make -j$(nproc) -B CC=gcc-${{ matrix.gcc-version }} CXFLAGS=-DEBIAN && make clean
         - name: 'Make with USE_PTHREADS flag'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-USE_PTHREADS && make clean
+          run: V=1 make -j$(nproc) -B CC=gcc-${{ matrix.gcc-version }} CXFLAGS=-USE_PTHREADS && make clean
         - name: 'Make with DNO_LIBUDEV flag'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc) -B CXFLAGS=-DNO_LIBUDEV && make clean
+          run: V=1 make -j$(nproc) -B CC=gcc-${{ matrix.gcc-version }} CXFLAGS=-DNO_LIBUDEV && make clean
         - name: 'Make'
-          run: CC=gcc-${{ matrix.gcc-version }} && V=1 make -j$(nproc)
+          run: V=1 make -j$(nproc) CC=gcc-${{ matrix.gcc-version }}
         - name: hardening-check mdadm
           run: hardening-check mdadm
         - name: hardening-check mdmon

--- a/super-intel.c
+++ b/super-intel.c
@@ -4324,6 +4324,12 @@ static void migrate(struct imsm_dev *dev, struct intel_super *super,
 static void end_migration(struct imsm_dev *dev, struct intel_super *super,
 			  __u8 map_state)
 {
+	/* To avoid compilation error, saying dev can't be NULL when
+	 * migr_state is assigned.
+	 */
+	if (dev == NULL)
+		return;
+
 	struct imsm_map *map = get_imsm_map(dev, MAP_0);
 	struct imsm_map *prev = get_imsm_map(dev, dev->vol.migr_state == 0 ?
 						    MAP_0 : MAP_1);


### PR DESCRIPTION
Fix compilation error. Set bit migr_state instead of assigning int
value.
Fix review.yml file, update gcc version used to build for each configuration from matrix.
Add new released gcc to compilation test during GH action.
Change runner to Ubuntu 24.04 which supports gcc versions up to 14.
Previously ubuntu-latest was used (22.04) which didn't support gcc 13
and 14. Add verification if correct gcc was installed during test.
