### PR TITLE
Grow_reshape: set only component_size for size grow

### DIFF
--- a/Grow.c
+++ b/Grow.c
@@ -2147,19 +2147,14 @@ int Grow_reshape(char *devname, int fd,
 		if (s->size == MAX_SIZE)
 			s->size = 0;
 		array.size = s->size;
-		if (s->size & ~INT32_MAX) {
-			/* got truncated to 32bit, write to
-			 * component_size instead
-			 */
-			rv = sysfs_set_num(sra, NULL, "component_size", s->size);
-		} else {
-			rv = md_set_array_info(fd, &array);
+		rv = sysfs_set_num(sra, NULL, "component_size", s->size);
 
-			/* manage array size when it is managed externally
-			 */
-			if ((rv == 0) && st->ss->external)
-				rv = set_array_size(st, sra, sra->text_version);
-		}
+		/*
+		 * For native metadata, md/array_size is updated by kernel,
+		 * for external management update it here.
+		 */
+		if (st->ss->external && rv == MDADM_STATUS_SUCCESS)
+			rv = set_array_size(st, sra, sra->text_version);
 
 		if (raid0_takeover) {
 			/* do not recync non-existing parity,


### PR DESCRIPTION
Component_size couldn't be set using ioctl when new drive size is big (e.g. 5TB). Command value is bigger than 32 bits and error is reported
- it is known ioctl limitation. Remove updating array properties using ioctl, use sysfs instead. Sysfs was introduced in 3.10, so now it is old enough to be safely used. Array_size in sysfs should be set for every size change for external metadata, when grow is performed without errors.