### PR TITLE
md.4: replace wrong word

### DIFF
--- a/md.4
+++ b/md.4
@@ -224,7 +224,7 @@ option.  If you use this option to
 while running a newer kernel, the array will NOT assemble, but the
 metadata will be update so that it can be assembled on an older kernel.
 
-No that setting the layout to "unspecified" removes protections against
+Note that setting the layout to "unspecified" removes protections against
 this bug, and you must be sure that the kernel you use matches the
 layout of the array.
 


### PR DESCRIPTION
There is a wrong word in the `md(4)` man page; the commit in this pull request corrects it.