### PR TITLE
mdstat: fix list detach issues

### DIFF
--- a/mdstat.c
+++ b/mdstat.c
@@ -123,13 +123,15 @@ static void mdstat_ent_list_detach_element(struct mdstat_ent **list_head, struct
 				ent->next = el->next;
 				break;
 			}
+
+			ent = ent->next;
 		}
 
-		ent = ent->next;
 	}
 
+	/* Guard if not found or list is empty - not allowed */
 	assert(ent);
-	ent->next = NULL;
+	el->next = NULL;
 }
 
 void free_mdstat(struct mdstat_ent *ms)


### PR DESCRIPTION
Move `ent = ent->next;` to while. It was outside the loop so if there are more than 2 elements and we are looking for 3rd element it causes infinite loop..

Fix `el->next` zeroing. It causes segfault in mdstat_free(). Theses issues were not visible in my testing because I had only 2 MD devices.