### PR TITLE
imsm: remove Intelx8 drives warning

### DIFF
--- a/platform-intel.c
+++ b/platform-intel.c
@@ -749,7 +749,8 @@ const struct imsm_orom *find_imsm_nvme(struct sys_dev *hba)
 			.vpa = IMSM_OROM_VOLUMES_PER_ARRAY,
 			.vphba = IMSM_OROM_TOTAL_DISKS_NVME / 2 * IMSM_OROM_VOLUMES_PER_ARRAY,
 			.attr = IMSM_OROM_ATTR_2TB | IMSM_OROM_ATTR_2TB_DISK,
-			.driver_features = IMSM_OROM_CAPABILITIES_EnterpriseSystem
+			.driver_features = IMSM_OROM_CAPABILITIES_EnterpriseSystem |
+					   IMSM_OROM_CAPABILITIES_TPV
 		};
 		nvme_orom = add_orom(&nvme_orom_compat);
 	}

--- a/super-intel.c
+++ b/super-intel.c
@@ -2663,9 +2663,12 @@ static void print_imsm_chunk_size_capability(const struct imsm_orom *orom)
 }
 
 
-static void print_imsm_capability(const struct imsm_orom *orom)
+static void print_imsm_capability(const struct orom_entry *entry)
 {
+	const struct imsm_orom *orom = &entry->orom;
+
 	printf("       Platform : Intel(R) ");
+
 	if (orom->capabilities == 0 && orom->driver_features == 0)
 		printf("Matrix Storage Manager\n");
 	else if (imsm_orom_is_enterprise(orom) && orom->major_ver >= 6)
@@ -2673,6 +2676,7 @@ static void print_imsm_capability(const struct imsm_orom *orom)
 	else
 		printf("Rapid Storage Technology%s\n",
 			imsm_orom_is_enterprise(orom) ? " enterprise" : "");
+
 	if (orom->major_ver || orom->minor_ver || orom->hotfix_ver || orom->build) {
 		if (imsm_orom_is_vmd_without_efi(orom))
 			printf("        Version : %d.%d\n", orom->major_ver, orom->minor_ver);
@@ -2690,11 +2694,19 @@ static void print_imsm_capability(const struct imsm_orom *orom)
 	printf("\n");
 
 	printf("    2TB volumes :%s supported\n", (orom->attr & IMSM_OROM_ATTR_2TB) ? "" : " not");
+
 	printf("      2TB disks :%s supported\n",
 	       (orom->attr & IMSM_OROM_ATTR_2TB_DISK) ? "" : " not");
+
 	printf("      Max Disks : %d\n", orom->tds);
+
 	printf("    Max Volumes : %d per array, %d per %s\n", orom->vpa, orom->vphba,
 	       imsm_orom_is_nvme(orom) ? "platform" : "controller");
+
+	if (entry->type == SYS_DEV_VMD || entry->type == SYS_DEV_NVME)
+		/* This is only meaningful for controllers with nvme support */
+		printf(" 3rd party NVMe :%s supported\n",
+		       imsm_orom_has_tpv_support(&entry->orom) ? "" : " not");
 	return;
 }
 
@@ -2733,26 +2745,25 @@ static int detail_platform_imsm(int verbose, int enumerate_only, char *controlle
 	 * platform capabilities.  If raid support is disabled in the BIOS the
 	 * option-rom capability structure will not be available.
 	 */
+	const struct orom_entry *entry;
 	struct sys_dev *list, *hba;
-	int host_base = 0;
+	struct devid_list *devid;
 	int port_count = 0;
-	int result=1;
+	int host_base = 0;
+	int result = 1;
 
 	if (enumerate_only) {
 		if (check_no_platform())
 			return 0;
+
 		list = find_intel_devices();
 		if (!list)
 			return 2;
-		for (hba = list; hba; hba = hba->next) {
-			if (find_imsm_capability(hba)) {
-				result = 0;
-				break;
-			}
-			else
-				result = 2;
-		}
-		return result;
+
+		for (hba = list; hba; hba = hba->next)
+			if (find_imsm_capability(hba))
+				return 0;
+		return 2;
 	}
 
 	list = find_intel_devices();
@@ -2768,6 +2779,7 @@ static int detail_platform_imsm(int verbose, int enumerate_only, char *controlle
 			continue;
 		if (!find_imsm_capability(hba)) {
 			char buf[PATH_MAX];
+
 			pr_err("imsm capabilities not found for controller: %s (type %s)\n",
 				  hba->type == SYS_DEV_VMD || hba->type == SYS_DEV_SATA_VMD ?
 				  vmd_domain_to_controller(hba, buf) :
@@ -2783,40 +2795,27 @@ static int detail_platform_imsm(int verbose, int enumerate_only, char *controlle
 		return result;
 	}
 
-	const struct orom_entry *entry;
-
 	for (entry = orom_entries; entry; entry = entry->next) {
-		if (entry->type == SYS_DEV_VMD) {
-			print_imsm_capability(&entry->orom);
-			printf(" 3rd party NVMe :%s supported\n",
-			    imsm_orom_has_tpv_support(&entry->orom)?"":" not");
+		print_imsm_capability(entry);
+
+		if (entry->type == SYS_DEV_VMD || entry->type == SYS_DEV_NVME) {
 			for (hba = list; hba; hba = hba->next) {
-				if (hba->type == SYS_DEV_VMD) {
-					char buf[PATH_MAX];
+				char buf[PATH_MAX];
+
+				if (hba->type != entry->type)
+					continue;
+
+				if (hba->type == SYS_DEV_VMD)
 					printf(" I/O Controller : %s (%s)\n",
-						vmd_domain_to_controller(hba, buf), get_sys_dev_type(hba->type));
-					if (print_nvme_info(hba)) {
-						if (verbose > 0)
-							pr_err("failed to get devices attached to VMD domain.\n");
-						result |= 2;
-					}
-				}
+					       vmd_domain_to_controller(hba, buf),
+					       get_sys_dev_type(hba->type));
+
+				print_nvme_info(hba);
 			}
 			printf("\n");
 			continue;
 		}
 
-		print_imsm_capability(&entry->orom);
-		if (entry->type == SYS_DEV_NVME) {
-			for (hba = list; hba; hba = hba->next) {
-				if (hba->type == SYS_DEV_NVME)
-					print_nvme_info(hba);
-			}
-			printf("\n");
-			continue;
-		}
-
-		struct devid_list *devid;
 		for (devid = entry->devid_list; devid; devid = devid->next) {
 			hba = device_by_id(devid->devid);
 			if (!hba)
@@ -6035,8 +6034,7 @@ static int add_to_super_imsm(struct supertype *st, mdu_disk_info_t *dk,
 			pr_err("%s controller supports Multi-Path I/O, Intel (R) VROC does not support multipathing\n",
 			       basename(cntrl_path));
 
-		if (super->hba->type == SYS_DEV_VMD && super->orom &&
-		    !imsm_orom_has_tpv_support(super->orom)) {
+		if (super->orom && !imsm_orom_has_tpv_support(super->orom)) {
 			pr_err("\tPlatform configuration does not support non-Intel NVMe drives.\n"
 			       "\tPlease refer to Intel(R) RSTe/VROC user guide.\n");
 			goto error;


### PR DESCRIPTION
These drives are not supported, remove warning.
It also adds 3th party nvmes support for NVMe orom, verification was skipped anyway.


Tested on my setup:

```bash
# ./mdadm --detail-pl
mdadm: imsm capabilities not found for controller: /sys/devices/pci0000:00/0000:00:17.0 (type SATA)
mdadm: imsm capabilities not found for controller: /sys/devices/pci0000:00/0000:00:11.5 (type SATA)
       Platform : Intel(R) Rapid Storage Technology enterprise
    RAID Levels : raid0 raid1 raid5 raid10
    Chunk Sizes : 4k 8k 16k 32k 64k 128k
    2TB volumes : supported
      2TB disks : supported
      Max Disks : 12
    Max Volumes : 2 per array, 12 per platform
 3rd party NVMe : supported
    NVMe Device : /dev/nvme1n1 (PHLJ914600HV1P0FGN)
                    Encryption(Ability|Status): None|Unencrypted

       Platform : Intel(R) Virtual RAID on CPU
        Version : 8.0.0.1386
    RAID Levels : raid0 raid1 raid5 raid10
    Chunk Sizes : 4k 8k 16k 32k 64k 128k
    2TB volumes : supported
      2TB disks : supported
      Max Disks : 96
    Max Volumes : 2 per array, 24 per controller
 3rd party NVMe : supported
 I/O Controller : /sys/devices/pci0000:17/0000:17:05.5 (VMD)
 NVMe under VMD : /dev/nvme3n1 (PHLF737200841P0GGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme6n1 (PHLJ915002N81P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme2n1 (PHLJ915000811P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme5n1 (PHLJ914600DV1P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 NVMe under VMD : /dev/nvme4n1 (PHLJ915003221P0FGN)
                    Encryption(Ability|Status): None|Unencrypted
 I/O Controller : /sys/devices/pci0000:85/0000:85:05.5 (VMD)
 I/O Controller : /sys/devices/pci0000:ae/0000:ae:05.5 (VMD)
 I/O Controller : /sys/devices/pci0000:5d/0000:5d:05.5 (VMD)
 NVMe under VMD : /dev/nvme7n1 (PHLJ914600H41P0FGN)
                    Encryption(Ability|Status): None|Unencrypted


```