### PR TITLE
Introduce new way of assemblation (v2)

### DIFF
--- a/Incremental.c
+++ b/Incremental.c
@@ -1499,15 +1499,6 @@ static int Incremental_container(struct supertype *st, char *devname,
 
 	st->ss->getinfo_super(st, &info, NULL);
 
-	if (info.container_enough < 0 || (info.container_enough == 0 && c->runstop < 1)) {
-		if (c->export)
-			printf("MD_STARTED=no\n");
-		else if (c->verbose)
-			pr_err("Not enough devices to start the container.\n");
-
-		return 0;
-	}
-
 	match = conf_match(st, &info, devname, c->verbose, &rv);
 	if (match == NULL && rv == 2)
 		return rv;

--- a/ReadMe.c
+++ b/ReadMe.c
@@ -213,6 +213,7 @@ struct option long_options[] = {
     /* For Incremental */
     {"rebuild-map", 0, 0, RebuildMapOpt},
     {"path", 1, 0, IncrementalPath},
+    {"force-set-array", 0, 0, ForceSetArray},
 
     {0, 0, 0, 0}
 };
@@ -603,15 +604,18 @@ char Help_incr[] =
 "and then both fail (if needed) and remove the device from that array.\n"
 "\n"
 "Options that are valid with incremental assembly (-I --incremental) are:\n"
-"  --run         -R : Run arrays as soon as a minimal number of devices are\n"
-"                   : present rather than waiting for all expected.\n"
-"  --quiet       -q : Don't print any information messages, just errors.\n"
-"  --rebuild-map -r : Rebuild the 'map' file that mdadm uses for tracking\n"
-"                   : partial arrays.\n"
-"  --scan        -s : Use with -R to start any arrays that have the minimal\n"
-"                   : required number of devices, but are not yet started.\n"
-"  --fail        -f : First fail (if needed) and then remove device from\n"
-"                   : any array that it is a member of.\n"
+"  --run          -R : Run arrays as soon as a minimal number of devices are\n"
+"                    : present rather than waiting for all expected.\n"
+"  --quiet        -q : Don't print any information messages, just errors.\n"
+"  --rebuild-map  -r : Rebuild the 'map' file that mdadm uses for tracking\n"
+"                    : partial arrays.\n"
+"  --scan         -s : Use with -R to start any arrays that have the minimal\n"
+"                    : required number of devices, but are not yet started.\n"
+"  --fail         -f : First fail (if needed) and then remove device from\n"
+"                    : any array that it is a member of.\n"
+"  --force-set-array : External metadata only! Force sysfs sync using already\n"
+"                      available array info. Use only in case of emergency.\n"
+"                      Note: Tested only with IMSM metadata!\n"
 ;
 
 char Help_config[] =

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -1875,6 +1875,17 @@ at specified path.   This option is normally only set by an
 .I udev
 script.
 
+.TP
+.BR \-\-force\-set\-array
+Note: valid only for external metadata, tested with IMSM only.
+Incremental assembly by default syncs sysfs with volume info only if enough
+drives are present for array to be started, otherwise only necessary
+entries are filled for volume to appear in
+.B /proc/mdstat.
+This option forces syncing all sysfs entries with metadata info already
+available. This might be helpful for recovering data from failed arrays.
+This option should not be used except emergency cases.
+
 .SH For Monitor mode:
 .TP
 .BR \-m ", " \-\-mail

--- a/mdadm.c
+++ b/mdadm.c
@@ -712,6 +712,9 @@ int main(int argc, char *argv[])
 		case O(MANAGE,Force): /* add device which is too large */
 			c.force = 1;
 			continue;
+		case O(INCREMENTAL, ForceSetArray): /* Force set sysfs with current content */
+			c.force_set_array = true;
+			continue;
 			/* now for the Assemble options */
 		case O(ASSEMBLE, FreezeReshape):   /* Freeze reshape during
 						    * initrd phase */

--- a/mdadm.h
+++ b/mdadm.h
@@ -391,13 +391,6 @@ struct mdinfo {
 	int container_member; /* for assembling external-metatdata arrays
 			       * This is to be used internally by metadata
 			       * handler only */
-	/**
-	 * flag external handlers can set to indicate that subarrays have:
-	 * - not enough disks to start (-1),
-	 * - enough disks to start (0),
-	 * - all expected disks (1).
-	 */
-	int container_enough;
 	char		sys_name[32];
 	struct mdinfo *devs;
 	struct mdinfo *next;

--- a/mdadm.h
+++ b/mdadm.h
@@ -540,6 +540,7 @@ enum special_options {
 	ClusterConfirm,
 	WriteJournal,
 	ConsistencyPolicy,
+	ForceSetArray
 };
 
 enum update_opt {
@@ -677,6 +678,7 @@ struct context {
 	char	*action;
 	int	nodes;
 	char	*homecluster;
+	bool	force_set_array;
 };
 
 struct shape {
@@ -2085,3 +2087,10 @@ static inline bool str_is_none(char *str)
 		return true;
 	return false;
 }
+
+/*
+ * Works like strncmp but does not check null terminator.
+ * To use when comparing read sysfs values.
+ * def should be an inline
+ */
+#define sysfs_strncmp(buf, def) (strncmp(buf, def, strlen(def)))

--- a/mdadm.h
+++ b/mdadm.h
@@ -1727,7 +1727,7 @@ extern unsigned long long calc_array_size(int level, int raid_disks, int layout,
 				   int chunksize, unsigned long long devsize);
 extern int flush_metadata_updates(struct supertype *st);
 extern void append_metadata_update(struct supertype *st, void *buf, int len);
-extern int assemble_container_content(struct supertype *st, int mdfd,
+extern mdadm_status_t assemble_container_content(struct supertype *st, int mdfd,
 				      struct mdinfo *content,
 				      struct context *c,
 				      char *chosen_name, int *result);

--- a/mdadm.h
+++ b/mdadm.h
@@ -377,6 +377,12 @@ struct mdinfo {
 	unsigned long long	ppl_sector;
 	unsigned long		safe_mode_delay; /* ms delay to mark clean */
 	int			new_level, delta_disks, new_layout, new_chunk;
+
+	/* Number of drives that needs rebuilding. */
+	int missing_disks;
+
+	/* Indicates that rebuild has not yet been started and is safe to start degraded array. */
+	bool			rebuild_started;
 	int			errors;
 	unsigned long		cache_size; /* size of raid456 stripe cache*/
 	int			mismatch_cnt;
@@ -448,6 +454,7 @@ typedef enum mdadm_status {
 	MDADM_STATUS_SUCCESS = 0,
 	MDADM_STATUS_ERROR,
 	MDADM_STATUS_UNDEF,
+	MDADM_STATUS_OPERATION_FAILED,
 } mdadm_status_t;
 
 enum mode {
@@ -831,6 +838,8 @@ extern int sysfs_attribute_available(struct mdinfo *sra, struct mdinfo *dev,
 extern int sysfs_get_str(struct mdinfo *sra, struct mdinfo *dev,
 			 char *name, char *val, int size);
 extern int sysfs_set_safemode(struct mdinfo *sra, unsigned long ms);
+extern int sysfs_init_array(struct mdinfo *info);
+int sysfs_update_raid_disks(struct mdinfo *info);
 extern int sysfs_set_array(struct mdinfo *info);
 extern int sysfs_add_disk(struct mdinfo *sra, struct mdinfo *sd, int resume);
 extern int sysfs_disk_to_scsi_id(int fd, __u32 *id);

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -1982,7 +1982,6 @@ static void getinfo_super_ddf(struct supertype *st, struct mdinfo *info, char *m
 	info->array.ctime	  = DECADE + __be32_to_cpu(*cptr);
 
 	info->array.chunk_size	  = 0;
-	info->container_enough	  = 1;
 
 	info->disk.major	  = 0;
 	info->disk.minor	  = 0;

--- a/super-intel.c
+++ b/super-intel.c
@@ -3748,7 +3748,6 @@ static void getinfo_super_imsm(struct supertype *st, struct mdinfo *info, char *
 	struct intel_super *super = st->sb;
 	struct imsm_disk *disk;
 	int map_disks = info->array.raid_disks;
-	int max_enough = -1;
 	int i;
 	struct imsm_super *mpb;
 
@@ -3790,12 +3789,9 @@ static void getinfo_super_imsm(struct supertype *st, struct mdinfo *info, char *
 
 	for (i = 0; i < mpb->num_raid_devs; i++) {
 		struct imsm_dev *dev = get_imsm_dev(super, i);
-		int failed, enough, j, missing = 0;
+		int j = 0;
 		struct imsm_map *map;
-		__u8 state;
 
-		failed = imsm_count_failed(super, dev, MAP_0);
-		state = imsm_check_degraded(super, dev, failed, MAP_0);
 		map = get_imsm_map(dev, MAP_0);
 
 		/* any newly missing disks?
@@ -3810,36 +3806,10 @@ static void getinfo_super_imsm(struct supertype *st, struct mdinfo *info, char *
 
 			if (!(ord & IMSM_ORD_REBUILD) &&
 			    get_imsm_missing(super, idx)) {
-				missing = 1;
 				break;
 			}
 		}
-
-		if (state == IMSM_T_STATE_FAILED)
-			enough = -1;
-		else if (state == IMSM_T_STATE_DEGRADED &&
-			 (state != map->map_state || missing))
-			enough = 0;
-		else /* we're normal, or already degraded */
-			enough = 1;
-		if (is_gen_migration(dev) && missing) {
-			/* during general migration we need all disks
-			 * that process is running on.
-			 * No new missing disk is allowed.
-			 */
-			max_enough = -1;
-			enough = -1;
-			/* no more checks necessary
-			 */
-			break;
-		}
-		/* in the missing/failed disk case check to see
-		 * if at least one array is runnable
-		 */
-		max_enough = max(max_enough, enough);
 	}
-
-	info->container_enough = max_enough;
 
 	if (super->disks) {
 		__u32 reserved = imsm_reserved_sectors(super, super->disks);

--- a/tests/22imsm-r5_3d_1s-verify-sysfs-integrity
+++ b/tests/22imsm-r5_3d_1s-verify-sysfs-integrity
@@ -1,0 +1,73 @@
+# Commit 4dde420fc3e2 ("mdadm: remove container_enough logic") introduced a bug,
+# where array sysfs info is obtained from first drive added and never updated.
+# This results in info mismatch if not "up to date" drive is added first.
+
+# We are testing ppl here as:
+# - we intend to show the problem exists
+# - it's a simple scenario without overcomplicating things
+. tests/env-imsm-template
+
+check_if_ppl() {
+       local vol=$1
+       sysfs_path=$(get_sysdir $vol)
+       result=$(cat $sysfs_path/consistency_policy)
+       if [ "$result" -ne "ppl" ]
+       then
+              echo >&2 "Expected consistency_policy \"ppl\" but was \"$1\""
+              exit 1
+       fi
+       return 0
+}
+
+num_disks=4
+level=5
+chunk=64
+offset=0
+# Workaround for loopback
+size=$((size/2))
+
+# Create imsm RAID 5 with single spare
+mdadm --create $container --metadata=imsm --raid-disks=$num_disks $dev0 $dev1 $dev2 $dev3 --run
+imsm_check container $num_disks
+
+mdadm --create $member0 --level=$level --size=$size --chunk=$chunk \
+      --raid-disks=$((num_disks-1)) $dev0 $dev1 $dev2 --assume-clean --run
+udevadm settle
+imsm_check member $member0 $((num_disks-1)) $level $size $((size*(num_disks-2))) $offset $chunk
+
+# Write config file
+mdadm --examine --brief --scan > $config
+
+# Incremental fail single drive
+mdadm --incremental --fail $(basename $dev0)
+check wait
+imsm_check member $member0 $((num_disks-1)) $level $size $((size*(num_disks-2))) $offset $chunk
+testdev $member0 $((num_disks-2)) $size $chunk
+
+# Stop volume
+mdadm --stop $member0
+
+# Change consistency_policy to PPL
+mdadm --update-subarray=0 --update=ppl $container
+
+# Assemble volume
+mdadm --assemble $member0 --config=$config --verbose
+imsm_check member $member0 $((num_disks-1)) $level $size $((size*(num_disks-2))) $offset $chunk
+testdev $member0 $((num_disks-2)) $size $chunk
+
+# Check if consistency_policy is "ppl"
+check_if_ppl $member0
+
+# Perform stop scan
+mdadm --stop --scan
+
+# Incrementally assemble array, start from failed drive
+for dev in $dev0 $dev1 $dev2 $dev3
+do
+       mdadm --incremental $dev --config=$config
+done
+imsm_check member $member0 $((num_disks-1)) $level $size $((size*(num_disks-2))) $offset $chunk
+testdev $member0 $((num_disks-2)) $size $chunk
+
+# Check if consistency_policy is "ppl"
+check_if_ppl $member0

--- a/tests/env-ddf-template
+++ b/tests/env-ddf-template
@@ -11,12 +11,6 @@ get_rootdev() {
     echo $bd
 }
 
-get_sysdir() {
-    local mddev=$1
-    [ -L $mddev ] && mddev=$(readlink -f $mddev)
-    echo "/sys/class/block/$(basename $mddev)/md"
-}
-
 get_raiddisks() {
     sysdir=$(get_sysdir "$1")
     for i in $(seq 0 $(($(cat $sysdir/raid_disks)-1))); do

--- a/tests/func.sh
+++ b/tests/func.sh
@@ -441,3 +441,9 @@ rotest() {
 	dev=$1
 	fsck -fn $dev >&2
 }
+
+get_sysdir() {
+    local mddev=$1
+    [ -L $mddev ] && mddev=$(readlink -f $mddev)
+    echo "/sys/class/block/$(basename $mddev)/md"
+}


### PR DESCRIPTION
This patchset changes current way of assemblation, so external metadata volumes are assembled but not started unitll sufficient number of drives is incrementally added.  This means that not started volumes will now be visible in mdstat. This is basically what https://github.com/md-raid-utilities/mdadm/commit/4dde420fc3e24077ab926f79674eaae1b71de10b tried to achieve but it compromised on many things. Until array is safe to start, only necessary sysfs entries are written to make array visible in mdstat. To force writing sysfs with full array info `--force-set-array` option is introduced.

About last-resort: This changes allow for last-resort feature to work for external metadata arrays. We will handle this by making it configurable (probably via conf file) in the future, in separate patchset.