### PR TITLE
mdadm: Change displaying of devices in --detail

### DIFF
--- a/Detail.c
+++ b/Detail.c
@@ -549,16 +549,10 @@ int Detail(char *dev, struct context *c)
 		} else if (inactive && !is_container) {
 			printf("             State : inactive\n");
 		}
-		if (array.raid_disks)
-			printf("    Active Devices : %d\n", array.active_disks);
-		if (array.working_disks > 0)
-			printf("   Working Devices : %d\n",
-			       array.working_disks);
-		if (array.raid_disks) {
-			printf("    Failed Devices : %d\n", array.failed_disks);
-			if (!external)
-				printf("     Spare Devices : %d\n", array.spare_disks);
-		}
+		printf("    Active Devices : %d\n", array.active_disks);
+		printf("   Working Devices : %d\n", array.working_disks);
+		printf("    Failed Devices : %d\n", array.failed_disks);
+		printf("     Spare Devices : %d\n", array.spare_disks);
 		printf("\n");
 		if (array.level == 5) {
 			str = map_num(r5layout, array.layout);


### PR DESCRIPTION
The counts of active, working, failed and spare devices were not printed when the number was zero.

Refactor the code to always display the counts of all device types, regardless of their number. This way, it is more reliable for users.