### PR TITLE
imsm: save checkpoint prior to exit

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -12631,8 +12631,6 @@ static int imsm_manage_reshape(
 			dprintf("wait_for_reshape_imsm returned error!\n");
 			goto abort;
 		}
-		if (sigterm)
-			goto abort;
 
 		if (save_checkpoint_imsm(st, sra, UNIT_SRC_NORMAL) == 1) {
 			/* ignore error == 2, this can mean end of reshape here
@@ -12640,6 +12638,9 @@ static int imsm_manage_reshape(
 			dprintf("imsm: Cannot write checkpoint to migration record (UNIT_SRC_NORMAL)\n");
 			goto abort;
 		}
+
+		if (sigterm)
+			goto abort;
 
 	}
 


### PR DESCRIPTION
If reshape (eg. chunksize migration) is gracefully stopped via SIGTERM the checkpoint is not saved and reshape cannot be resumed due to "data being present in copy area". This is because UNIT_SRC_NORMAL isn't set if SIGTERM occured.

Move SIGTERM handling at the end of the loop to allow saving checkpoint (and state) so reshapes can be properly resumed.