### PR TITLE
CI: use self-hosted runner to run tests

### DIFF
--- a/.github/tools/run_mdadm_tests.sh
+++ b/.github/tools/run_mdadm_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+sudo make clean
+sudo make -j$(nproc)
+sudo make install
+sudo mdadm -Ss
+sudo ./test setup
+ret=$(sudo ./test --skip-broken --no-error --disable-integrity --disable-multipath --disable-linear --keep-going)
+sudo ./test cleanup
+exit $ret

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+name: tests
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - '*.c'
+      - '*.h'
+jobs:
+  upstream_tests:
+     if: ${{ github.repository == 'md-raid-utilities/mdadm' }}
+     runs-on: self-hosted
+     timeout-minutes: 150
+     name: upstream tests
+     steps:
+     - uses: actions/checkout@v4
+       if: ${{ github.event_name == 'pull_request' }}
+       with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+     - uses: actions/checkout@v4
+       if: ${{ github.event_name == 'schedule' }}
+       with:
+        ref: main
+        fetch-depth: 0
+     - name: 'Prepare machine'
+       run: |
+          cd ..
+          vagrant halt
+          vagrant status
+          vagrant up
+     - name: 'Run tests'
+       run: |
+          cd ..
+          vagrant ssh -c "cd /home/vagrant/host/mdadm && .github/tools/run_mdadm_tests.sh"
+     - name: 'Copy logs to host machine'
+       run: |
+          cd ..
+          vagrant ssh -c "sudo mkdir -p /home/vagrant/host/logs && sudo mv /var/tmp/*.log /home/vagrant/host/logs"
+     - name: "Save artifacts"
+       uses: actions/upload-artifact@v4
+       with:
+         name: "Logs from failed tests"
+         path: /home/ci/actions-runner/_work/mdadm/logs/*.log
+     - name: "Clean logs"
+       run: |
+          cd ..
+          sudo rm /home/ci/actions-runner/_work/mdadm/logs/*.log
+  cleanup:
+    runs-on: self-hosted
+    needs: [upstream_tests]
+    steps:
+      - name: Restore clean VM
+        run:  |
+          cd ..
+          vagrant up
+          vagrant ssh -c "sudo mdadm -Ss"
+          vagrant halt


### PR DESCRIPTION
Use prepared VM machine in GitHub actions to run mdadm tests on it.