### PR TITLE
Incremental: support devnode in IncrementalRemove.

### DIFF
--- a/mdadm.h
+++ b/mdadm.h
@@ -100,6 +100,11 @@ struct dlm_lksb {
 #define DEFAULT_BITMAP_DELAY 5
 #define DEFAULT_MAX_WRITE_BEHIND 256
 
+#ifndef DEV_DIR
+#define DEV_DIR "/dev/"
+#define DEV_DIR_LEN (sizeof(DEV_DIR) - 1)
+#endif /* DEV_DIR */
+
 /* DEV_NUM_PREF is a subpath to numbered MD devices, e.g. /dev/md1 or directory name.
  * DEV_NUM_PREF_LEN is a length with Null byte excluded.
  */

--- a/udev-md-raid-assembly.rules
+++ b/udev-md-raid-assembly.rules
@@ -41,7 +41,7 @@ ACTION=="change", KERNEL!="dm-*|md*", GOTO="md_inc_end"
 ACTION!="remove", IMPORT{program}="BINDIR/mdadm --incremental --export $devnode --offroot $env{DEVLINKS}"
 ACTION!="remove", ENV{MD_STARTED}=="*unsafe*", ENV{MD_FOREIGN}=="no", ENV{SYSTEMD_WANTS}+="mdadm-last-resort@$env{MD_DEVICE}.timer"
 
-ACTION=="remove", ENV{ID_PATH}=="?*", RUN+="BINDIR/mdadm -If $name --path $env{ID_PATH}"
-ACTION=="remove", ENV{ID_PATH}!="?*", RUN+="BINDIR/mdadm -If $name"
+ACTION=="remove", ENV{ID_PATH}=="?*", RUN+="BINDIR/mdadm -If $devnode --path $env{ID_PATH}"
+ACTION=="remove", ENV{ID_PATH}!="?*", RUN+="BINDIR/mdadm -If $devnode"
 
 LABEL="md_inc_end"


### PR DESCRIPTION
There are no reasons to keep this interface different than others. Allow to use devnode but keep old way for backward compatibility. Method is added to verify that only devnode or kernel name is used.

Testing on my setup passed. I used raid0, so removal failed, but I checked parsing.
```bash
[gklab-localhost ~/mtkaczyk_work/mdadm/mdadm-github]# ./mdadm -If /dev/nvme5n1
mdadm: set device faulty failed for nvme5n1:  Device or resource busy
mdadm: nvme5n1 is still in use, cannot remove.
[gklab-localhost ~/mtkaczyk_work/mdadm/mdadm-github]# ./mdadm -If /dev/md/nvme5n1
mdadm: Cannot remove "/dev/md/nvme5n1", devnode path or kernel device name is allowed.
[gklab-localhost ~/mtkaczyk_work/mdadm/mdadm-github]# ./mdadm -If /dev/disk/by-path/pci-0000\:00\:11.5-ata-5-part4
mdadm: Cannot remove "/dev/disk/by-path/pci-0000:00:11.5-ata-5-part4", devnode path or kernel device name is allowed.
[gklab-localhost ~/mtkaczyk_work/mdadm/mdadm-github]# ./mdadm -If nvmex5n1

```

