### PR TITLE
mdadm: add xmalloc.h

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -23,6 +23,8 @@
  */
 
 #include	"mdadm.h"
+#include	"xmalloc.h"
+
 #include	<ctype.h>
 
 mapping_t assemble_statuses[] = {

--- a/Create.c
+++ b/Create.c
@@ -23,9 +23,11 @@
  */
 
 #include	"mdadm.h"
-#include	"udev.h"
 #include	"md_u.h"
 #include	"md_p.h"
+#include	"udev.h"
+#include	"xmalloc.h"
+
 #include	<ctype.h>
 #include	<fcntl.h>
 #include	<signal.h>

--- a/Detail.c
+++ b/Detail.c
@@ -25,6 +25,8 @@
 #include	"mdadm.h"
 #include	"md_p.h"
 #include	"md_u.h"
+#include	"xmalloc.h"
+
 #include	<ctype.h>
 #include	<dirent.h>
 

--- a/Examine.c
+++ b/Examine.c
@@ -22,14 +22,16 @@
  *    Email: <neilb@suse.de>
  */
 
-#include	"mdadm.h"
 #include	"dlink.h"
+#include	"mdadm.h"
+#include	"md_u.h"
+#include	"md_p.h"
+#include	"xmalloc.h"
 
 #if ! defined(__BIG_ENDIAN) && ! defined(__LITTLE_ENDIAN)
 #error no endian defined
 #endif
-#include	"md_u.h"
-#include	"md_p.h"
+
 int Examine(struct mddev_dev *devlist,
 	    struct context *c,
 	    struct supertype *forcest)

--- a/Grow.c
+++ b/Grow.c
@@ -23,6 +23,8 @@
  */
 #include	"mdadm.h"
 #include	"dlink.h"
+#include	"xmalloc.h"
+
 #include	<sys/mman.h>
 #include	<stddef.h>
 #include	<stdint.h>

--- a/Incremental.c
+++ b/Incremental.c
@@ -29,6 +29,8 @@
  */
 
 #include	"mdadm.h"
+#include	"xmalloc.h"
+
 #include	<sys/wait.h>
 #include	<dirent.h>
 #include	<ctype.h>

--- a/Manage.c
+++ b/Manage.c
@@ -26,6 +26,8 @@
 #include "md_u.h"
 #include "md_p.h"
 #include "udev.h"
+#include "xmalloc.h"
+
 #include <ctype.h>
 
 int Manage_ro(char *devname, int fd, int readonly)

--- a/Monitor.c
+++ b/Monitor.c
@@ -23,9 +23,11 @@
  */
 
 #include	"mdadm.h"
-#include	"udev.h"
 #include	"md_p.h"
 #include	"md_u.h"
+#include	"udev.h"
+#include	"xmalloc.h"
+
 #include	<sys/wait.h>
 #include	<limits.h>
 #include	<syslog.h>

--- a/bitmap.c
+++ b/bitmap.c
@@ -19,6 +19,7 @@
  */
 
 #include "mdadm.h"
+#include "xmalloc.h"
 
 static inline void sb_le_to_cpu(bitmap_super_t *sb)
 {

--- a/config.c
+++ b/config.c
@@ -24,6 +24,8 @@
 
 #include	"mdadm.h"
 #include	"dlink.h"
+#include	"xmalloc.h"
+
 #include	<dirent.h>
 #include	<glob.h>
 #include	<fnmatch.h>

--- a/lib.c
+++ b/lib.c
@@ -24,6 +24,8 @@
 
 #include	"mdadm.h"
 #include	"dlink.h"
+#include	"xmalloc.h"
+
 #include	<ctype.h>
 #include	<limits.h>
 

--- a/managemon.c
+++ b/managemon.c
@@ -104,6 +104,8 @@
 #endif
 #include	"mdadm.h"
 #include	"mdmon.h"
+#include	"xmalloc.h"
+
 #include	<sys/syscall.h>
 #include	<sys/socket.h>
 

--- a/mapfile.c
+++ b/mapfile.c
@@ -43,6 +43,8 @@
  * at compile time via MAP_DIR and MAP_FILE.
  */
 #include	"mdadm.h"
+#include	"xmalloc.h"
+
 #include	<sys/file.h>
 #include	<ctype.h>
 

--- a/mdadm.c
+++ b/mdadm.c
@@ -27,6 +27,8 @@
 
 #include "mdadm.h"
 #include "md_p.h"
+#include "xmalloc.h"
+
 #include <ctype.h>
 
 /**

--- a/mdadm.h
+++ b/mdadm.h
@@ -1934,11 +1934,6 @@ static inline int xasprintf(char **strp, const char *fmt, ...) {
 
 #define pr_vrb(fmt, arg...) ((void)(verbose && pr_err(fmt, ##arg)))
 
-void *xmalloc(size_t len);
-void *xrealloc(void *ptr, size_t len);
-void *xcalloc(size_t num, size_t size);
-char *xstrdup(const char *str);
-
 #define	LEVEL_MULTIPATH		(-4)
 #define	LEVEL_LINEAR		(-1)
 #define	LEVEL_FAULTY		(-5)

--- a/mdmon.c
+++ b/mdmon.c
@@ -65,6 +65,7 @@
 
 #include	"mdadm.h"
 #include	"mdmon.h"
+#include	"xmalloc.h"
 
 char const Name[] = "mdmon";
 

--- a/mdopen.c
+++ b/mdopen.c
@@ -25,6 +25,8 @@
 #include "mdadm.h"
 #include "udev.h"
 #include "md_p.h"
+#include "xmalloc.h"
+
 #include <ctype.h>
 
 void make_parts(char *dev, int cnt)

--- a/mdstat.c
+++ b/mdstat.c
@@ -80,6 +80,8 @@
 
 #include	"mdadm.h"
 #include	"dlink.h"
+#include	"xmalloc.h"
+
 #include	<sys/select.h>
 #include	<ctype.h>
 

--- a/msg.c
+++ b/msg.c
@@ -30,6 +30,7 @@
 #include <sys/un.h>
 #include "mdadm.h"
 #include "mdmon.h"
+#include "xmalloc.h"
 
 static const __u32 start_magic = 0x5a5aa5a5;
 static const __u32 end_magic = 0xa5a55a5a;

--- a/platform-intel.c
+++ b/platform-intel.c
@@ -19,6 +19,8 @@
 #include "mdadm.h"
 #include "platform-intel.h"
 #include "probe_roms.h"
+#include "xmalloc.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/policy.c
+++ b/policy.c
@@ -23,6 +23,8 @@
  */
 
 #include "mdadm.h"
+#include "xmalloc.h"
+
 #include <dirent.h>
 #include <fnmatch.h>
 #include <ctype.h>

--- a/restripe.c
+++ b/restripe.c
@@ -23,6 +23,8 @@
  */
 
 #include "mdadm.h"
+#include "xmalloc.h"
+
 #include <stdint.h>
 
 /* To restripe, we read from old geometry to a buffer, and

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -29,6 +29,8 @@
 #include "mdadm.h"
 #include "mdmon.h"
 #include "sha1.h"
+#include "xmalloc.h"
+
 #include <values.h>
 #include <stddef.h>
 

--- a/super-gpt.c
+++ b/super-gpt.c
@@ -40,6 +40,7 @@
 
 #include "mdadm.h"
 #include "part.h"
+#include "xmalloc.h"
 
 static void free_gpt(struct supertype *st)
 {

--- a/super-intel.c
+++ b/super-intel.c
@@ -23,6 +23,8 @@
 #include "dlink.h"
 #include "sha1.h"
 #include "platform-intel.h"
+#include "xmalloc.h"
+
 #include <values.h>
 #include <scsi/sg.h>
 #include <ctype.h>

--- a/super-mbr.c
+++ b/super-mbr.c
@@ -41,6 +41,7 @@
 
 #include "mdadm.h"
 #include "part.h"
+#include "xmalloc.h"
 
 static void free_mbr(struct supertype *st)
 {

--- a/super0.c
+++ b/super0.c
@@ -25,6 +25,8 @@
 #define HAVE_STDINT_H 1
 #include "mdadm.h"
 #include "sha1.h"
+#include "xmalloc.h"
+
 /*
  * All handling for the 0.90.0 version superblock is in
  * this file.

--- a/super1.c
+++ b/super1.c
@@ -24,6 +24,8 @@
 
 #include <stddef.h>
 #include "mdadm.h"
+#include "xmalloc.h"
+
 /*
  * The version-1 superblock :
  * All numeric fields are little-endian.

--- a/sysfs.c
+++ b/sysfs.c
@@ -24,9 +24,11 @@
  */
 
 #include	"mdadm.h"
+#include	"dlink.h"
+#include	"xmalloc.h"
+
 #include	<dirent.h>
 #include	<ctype.h>
-#include	"dlink.h"
 
 #define MAX_SYSFS_PATH_LEN	120
 

--- a/udev.c
+++ b/udev.c
@@ -22,6 +22,8 @@
 #include	"udev.h"
 #include	"md_p.h"
 #include	"md_u.h"
+#include	"xmalloc.h"
+
 #include	<sys/wait.h>
 #include	<signal.h>
 #include	<limits.h>

--- a/util.c
+++ b/util.c
@@ -24,6 +24,8 @@
 
 #include	"mdadm.h"
 #include	"md_p.h"
+#include	"xmalloc.h"
+
 #include	<sys/socket.h>
 #include	<sys/utsname.h>
 #include	<sys/wait.h>

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -21,64 +21,57 @@
  *    Email: <neilb@suse.de>
  */
 
-#include	"mdadm.h"
-/*#include	<sys/socket.h>
-#include	<sys/utsname.h>
-#include	<sys/wait.h>
-#include	<sys/un.h>
-#include	<ctype.h>
-#include	<dirent.h>
-#include	<signal.h>
-*/
+#include "xmalloc.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void *exit_memory_alloc_failure(void)
+{
+	fprintf(stderr, "Memory allocation failure - aborting\n");
+
+	/* TODO: replace with MDADM_STATUS_MEM_FAIL */
+	exit(1);
+}
 
 void *xmalloc(size_t len)
 {
 	void *rv = malloc(len);
-	char *msg;
-	int n;
+
 	if (rv)
 		return rv;
-	msg = ": memory allocation failure - aborting\n";
-	n = write(2, Name, strlen(Name));
-	n += write(2, msg, strlen(msg));
-	exit(4+!!n);
+
+	return exit_memory_alloc_failure();
 }
 
 void *xrealloc(void *ptr, size_t len)
 {
 	void *rv = realloc(ptr, len);
-	char *msg;
-	int n;
+
 	if (rv)
 		return rv;
-	msg =  ": memory allocation failure - aborting\n";
-	n = write(2, Name, strlen(Name));
-	n += write(2, msg, strlen(msg));
-	exit(4+!!n);
+
+	return exit_memory_alloc_failure();
 }
 
 void *xcalloc(size_t num, size_t size)
 {
 	void *rv = calloc(num, size);
-	char *msg;
-	int n;
+
 	if (rv)
 		return rv;
-	msg =  ": memory allocation failure - aborting\n";
-	n = write(2, Name, strlen(Name));
-	n += write(2, msg, strlen(msg));
-	exit(4+!!n);
+
+	return exit_memory_alloc_failure();
 }
 
 char *xstrdup(const char *str)
 {
 	char *rv = strdup(str);
-	char *msg;
-	int n;
+
 	if (rv)
 		return rv;
-	msg =  ": memory allocation failure - aborting\n";
-	n = write(2, Name, strlen(Name));
-	n += write(2, msg, strlen(msg));
-	exit(4+!!n);
+
+	return exit_memory_alloc_failure();
 }

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef XMALLOC_H
+#define XMALLOC_H
+
+#include <stddef.h>
+
+void *xmalloc(size_t len);
+void *xrealloc(void *ptr, size_t len);
+void *xcalloc(size_t num, size_t size);
+char *xstrdup(const char *str);
+
+#endif


### PR DESCRIPTION
Move memory declaration helpers outside mdadm.h. They seems to be useful so keep them but include separatelly. Rework them to not reffer to Name[] declared internally in mdadm/mdmon.

This is first step to start decomplexing mdadm.h.