### PR TITLE
Improve mdadm and mdadm.conf manuals

### DIFF
--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -1830,6 +1830,16 @@ can be found it
 under
 .BR "SCRUBBING AND MISMATCHES" .
 
+.TP
+.B \-\-udev\-rules=
+it generates the udev rules to the file that handles hot-plug bare devices.
+Given the POLICYs defined under
+.IR {CONFFILE}\ (or {CONFFILE2})
+
+See
+.BR mdadm.conf (5)
+for more details and usage examples about POLICY.
+
 .SH For Incremental Assembly mode:
 .TP
 .BR \-\-rebuild\-map ", " \-r

--- a/mdadm.conf.5.in
+++ b/mdadm.conf.5.in
@@ -506,8 +506,12 @@ of the new disk or if both arrays have the same
 .IR spare-group .
 
 To update hot plug configuration it is necessary to execute
-.B mdadm \-\-udev\-rules
-command after changing the config file
+.B mdadm \-\-udev\-rules\=<path_to_file>
+e.g.
+.B /etc/udev/rules.d/65-md-bare.rules
+command after changing the config file. And also run
+.B udevadm control \-\-reload
+otherwise, a reboot is needed.
 
 Keywords used in the
 .I POLICY
@@ -724,14 +728,6 @@ ARRAY /dev/md/home UUID=9187a482:5dde19d9:eea3cc4a:d646ab8b
 .br
            auto=part
 .br
-POLICY domain=domain1 metadata=imsm path=pci-0000:00:1f.2-scsi-*
-.br
-           action=spare
-.br
-POLICY domain=domain1 metadata=imsm path=pci-0000:04:00.0-scsi-[01]*
-.br
-           action=include
-.br
 # One domain comprising of devices attached to specified paths is defined.
 .br
 # Bare device matching first path will be made an imsm spare on hot plug.
@@ -741,6 +737,14 @@ POLICY domain=domain1 metadata=imsm path=pci-0000:04:00.0-scsi-[01]*
 # one of them becomes degraded, then any imsm spare matching any path for
 .br
 # given domain name can be migrated.
+.br
+POLICY domain=domain1 metadata=imsm path=pci-0000:00:1f.2-scsi-*
+.br
+           action=spare
+.br
+POLICY domain=domain1 metadata=imsm path=pci-0000:04:00.0-scsi-[01]*
+.br
+           action=include
 .br
 MAILADDR root@mydomain.tld
 .br


### PR DESCRIPTION
The `--udev-rules` flag was barely mentioned under manuals, so I added a bit into both.
