### PR TITLE
func.sh: do not hang when grow-continue can't finish

### DIFF
--- a/tests/07reshape5intr
+++ b/tests/07reshape5intr
@@ -31,7 +31,21 @@ do
   echo 1000 > /proc/sys/dev/raid/speed_limit_min
   echo 2000 > /proc/sys/dev/raid/speed_limit_max
   check wait
-  while ! echo check > /sys/block/md0/md/sync_action; do sleep 0.1; done
+
+  max=5
+
+  for ((i = 0 ; i < max ; i++ )); do
+    if [[ $(echo check > /sys/block/md0/md/sync_action) != 0 ]]; then
+        break;
+    fi
+    sleep 1
+  done
+
+  if [[ i == max ]]; then
+     echo >&2 "Timeout waiting for check to succeed"
+     exit 1
+  fi
+
   check wait
   mm=`cat /sys/block/md0/md/mismatch_cnt`
   if [ $mm -gt 0 ]

--- a/tests/imsm-grow-template
+++ b/tests/imsm-grow-template
@@ -103,9 +103,7 @@ else
 			exit 1
 		fi
 	else
-		sleep 5
 		check wait
-		sleep 5
 		check wait
 		imsm_check member $member0 $num_disks $vol0_level $vol0_comp_size $((vol0_comp_size * vol0_new_num_comps)) $vol0_offset $vol0_chunk
 		testdev $member0 $vol0_new_num_comps $vol0_comp_size $vol0_chunk


### PR DESCRIPTION
When grow-continue process is on, the sync_action represents value which means that recovery is in progress. When grow-continue does not finish, even if sync_action is not reshape anymore, test should fail.