### PR TITLE
[PATCH] Coverity check resource fixes

### DIFF
--- a/Dump.c
+++ b/Dump.c
@@ -207,7 +207,11 @@ int Restore_metadata(char *dev, char *dir, struct context *c,
 		char *chosen = NULL;
 		unsigned int chosen_inode = 0;
 
-		fstat(fd, &dstb);
+		if (fstat(fd, &dstb) != 0) {
+			closedir(d);
+			close(fd);
+			return 1;
+		}
 
 		while (d && (de = readdir(d)) != NULL) {
 			if (de->d_name[0] == '.')
@@ -313,8 +317,8 @@ int Restore_metadata(char *dev, char *dir, struct context *c,
 	}
 	if (c->verbose >= 0)
 		printf("%s restored from %s.\n", dev, fname);
-	close(fl);
 	close(fd);
+	close(fl);
 	free(fname);
 	return 0;
 

--- a/Manage.c
+++ b/Manage.c
@@ -1577,8 +1577,8 @@ int Manage_subdevs(char *devname, int fd,
 		} else {
 			tfd = dev_open(dv->devname, O_RDONLY);
 			if (tfd >= 0) {
-				fstat_is_blkdev(tfd, dv->devname, &rdev);
-				close_fd(&tfd);
+				if (!fstat_is_blkdev(tfd, dv->devname, &rdev))
+					close_fd(&tfd);
 			} else {
 				int open_err = errno;
 				if (!stat_is_blkdev(dv->devname, &rdev)) {
@@ -1601,6 +1601,7 @@ int Manage_subdevs(char *devname, int fd,
 					goto abort;
 				}
 			}
+			close_fd(&tfd);
 		}
 		switch(dv->disposition){
 		default:
@@ -1756,6 +1757,7 @@ int Manage_subdevs(char *devname, int fd,
 	return 0;
 
 abort:
+	close_fd(&tfd);
 	free(tst);
 	if (frozen > 0)
 		sysfs_set_str(&info, NULL, "sync_action","idle");

--- a/managemon.c
+++ b/managemon.c
@@ -387,14 +387,17 @@ static void manage_container(struct mdstat_ent *mdstat,
 
 static int sysfs_open2(char *devnum, char *name, char *attr)
 {
+	char buf[SYSFS_MAX_BUF_SIZE];
+
 	int fd = sysfs_open(devnum, name, attr);
 	if (fd >= 0) {
 		/* seq_file in the kernel allocates buffer space
 		 * on the first read.  Do that now so 'monitor'
 		 * never needs too.
 		 */
-		char buf[200];
-		if (read(fd, buf, sizeof(buf)) < 0)
+		int n = read(fd, buf, sizeof(buf));
+
+		if (n <= 0 || n == sizeof(buf))
 			/* pretend not to ignore return value */
 			return fd;
 	}

--- a/monitor.c
+++ b/monitor.c
@@ -485,7 +485,10 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 		 * wasn't requested, transition to read-auto.
 		 */
 		char buf[64];
-		read_attr(buf, sizeof(buf), a->metadata_fd);
+		int n = read_attr(buf, sizeof(buf), a->metadata_fd);
+
+		if (n <= 0)
+			return 0;
 		if (strncmp(buf, "external:-", 10) == 0) {
 			/* explicit request for readonly array.  Leave it alone */
 			;

--- a/super-intel.c
+++ b/super-intel.c
@@ -12969,7 +12969,8 @@ static int locate_bitmap_imsm(struct supertype *st, int fd, int node_num)
 	offset = get_bitmap_header_sector(super, super->current_vol);
 	dprintf("bitmap header offset is %llu\n", offset);
 
-	lseek64(fd, offset << 9, 0);
+	if (lseek64(fd, offset << 9, 0) < 0LL)
+		return -1;
 
 	return 0;
 }
@@ -13023,7 +13024,8 @@ static int write_init_bitmap_imsm(struct supertype *st, int fd,
 		return -1;
 	memset(buf, 0xFF, MAX_SECTOR_SIZE);
 	offset = get_bitmap_sector(super, vol_idx);
-	lseek64(fd, offset << 9, 0);
+	if (lseek64(fd, offset << 9, 0) < 0LL)
+		return -1;
 	while (written < IMSM_BITMAP_AREA_SIZE) {
 		to_write = IMSM_BITMAP_AREA_SIZE - written;
 		if (to_write > MAX_SECTOR_SIZE)


### PR DESCRIPTION
Converity is flagging the following errors:y
Event check_return: Calling without checking return value. This library function may fail and return an error code.