### PR TITLE
Coverity fixes resources leaks

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -764,6 +764,7 @@ static int load_devices(struct devs *devices, char *devmap,
 			tst->ss->free_super(tst);
 			free(tst);
 			*stp = st;
+			free(best);
 			return -1;
 		}
 		close(dfd);
@@ -845,7 +846,6 @@ static int load_devices(struct devs *devices, char *devmap,
 				       inargv ? "the list" :
 				       "the\n      DEVICE list in mdadm.conf"
 					);
-				free(best);
 				*stp = st;
 				goto error;
 			}
@@ -868,6 +868,7 @@ error:
 	close(mdfd);
 	free(devices);
 	free(devmap);
+	free(best);
 	return -1;
 
 }

--- a/Incremental.c
+++ b/Incremental.c
@@ -294,7 +294,7 @@ int Incremental(struct mddev_dev *devlist, struct context *c,
 		 * clustering resource agents
 		 */
 		if (info.array.state & (1 << MD_SB_CLUSTERED))
-			goto out;
+			goto out_unlock;
 
 		/* Couldn't find an existing array, maybe make a new one */
 		mdfd = create_mddev(match ? match->devname : NULL,

--- a/bitmap.c
+++ b/bitmap.c
@@ -256,8 +256,11 @@ int ExamineBitmap(char *filename, int brief, struct supertype *st)
 		return rv;
 
 	info = bitmap_fd_read(fd, brief);
-	if (!info)
+	if (!info) {
+		close_fd(&fd);
+		free(info);
 		return rv;
+	}
 	sb = &info->sb;
 	if (sb->magic != BITMAP_MAGIC) {
 		pr_err("This is an md array.  To view a bitmap you need to examine\n");
@@ -332,7 +335,6 @@ int ExamineBitmap(char *filename, int brief, struct supertype *st)
 		printf("    Cluster name : %-64s\n", sb->cluster_name);
 		for (i = 0; i < (int)sb->nodes; i++) {
 			st = NULL;
-			free(info);
 			fd = bitmap_file_open(filename, &st, i, fd);
 			if (fd < 0) {
 				printf("   Unable to open bitmap file on node: %i\n", i);
@@ -343,6 +345,7 @@ int ExamineBitmap(char *filename, int brief, struct supertype *st)
 				printf("   Unable to read bitmap on node: %i\n", i);
 				continue;
 			}
+			free(sb);
 			sb = &info->sb;
 			if (sb->magic != BITMAP_MAGIC)
 				pr_err("invalid bitmap magic 0x%x, the bitmap file appears to be corrupted\n", sb->magic);


### PR DESCRIPTION
Handle variable going out of scope leaks the handle.