### PR TITLE
Release mdadm-4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+# Release [mdadm-4.4](https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/log/?h=mdadm-4.4)
+
+Features:
+- Remobe custom bitmap file support from Yu Kuai.
+- Custom device policies implementation from Mariusz Tkaczyk.
+- Self encrypted drives (**SED**) support for IMSM metadata from Blazej Kucman.
+- Support more than 4 disks for **IMSM** RAID10 from Mateusz Kusiak.
+- Read **IMSM** license information from ACPI tables from Blazej Kucman.
+- Support devnode in **--Incremental --remove** from Mariusz Tkaczyk.
+- Printing **IMSM** license type in **--detail-platform** from Blazej Kucman.
+- README.md from Mariusz Tkaczyk and Anna Sztukowska.
+
+Fixes:
+- Tests improvements from Xiao Ni and Kinga Stefaniuk.
+- Mdmon's Checkpointing improvements from Mateusz Kusiak.
+- Pass mdadm environment flags to systemd-env to enable tests from Mateusz Kusiak.
+- Superblock 1.0 uuid printing fixes from Mariusz Tkaczyk.
+- Find VMD bus manually if link is not available from Mariusz Tkaczyk.
+- Unconditional devices count printing in --detail from Anna Sztukowska.
+- Improve SIGTERM handling during reshape, from Mateusz Kusiak.
+- **Monitor.c** renamed to **Mdmonitor.c** from Kinga Stefaniuk.
+- Mdmonitor service documentation update from Mariusz Tkaczyk.
+- Rework around writing to sysfs files from Mariusz Tkaczyk.
+- Drop of HOT_REMOVE_DISK ioctl in Manage in favour of sysfs from Mariusz Tkaczyk.
+- Delegate disk removal to managemon from Mariusz Tkaczyk.
+- Some clean-ups of legacy code and functionalities like **--auto=md** from Mariusz Tkaczyk.
+- Manual clean-up, references to old kernels removed from Mariusz Tkaczyk.
+- Various static code analysis fixes.
+
+In this release we created github repository and allowed participation through
+Github. It allowed us to use Github actions adn create CI. Currently, we have:
+- Compilation tests with various gcc.
+- **mdadm** tests.
+- Checkpatch test.
+
 # Release [mdadm-4.3](https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/log/?h=mdadm-4.3)
 
 Features:

--- a/ReadMe.c
+++ b/ReadMe.c
@@ -28,10 +28,10 @@
 #include "mdadm.h"
 
 #ifndef VERSION
-#define VERSION "4.3"
+#define VERSION "4.4"
 #endif
 #ifndef VERS_DATE
-#define VERS_DATE "2024-02-15"
+#define VERS_DATE "2024-11-07"
 #endif
 #ifndef EXTRAVERSION
 #define EXTRAVERSION ""

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -5,7 +5,7 @@
 .\"   the Free Software Foundation; either version 2 of the License, or
 .\"   (at your option) any later version.
 .\" See file COPYING in distribution for details.
-.TH MDADM 8 "" v4.3
+.TH MDADM 8 "" v4.4
 .SH NAME
 mdadm \- manage MD devices
 .I aka

--- a/mdmon.8
+++ b/mdmon.8
@@ -1,5 +1,5 @@
 .\" See file COPYING in distribution for details.
-.TH MDMON 8 "" v4.3
+.TH MDMON 8 "" v4.4
 .SH NAME
 mdmon \- monitor MD external metadata arrays
 


### PR DESCRIPTION
```
WARNING:COMMIT_MESSAGE: Missing commit description - Add an appropriate one
Error: WARNING:COMMIT_MESSAGE: Missing commit description - Add an appropriate one
```
This is fine in this case. It is to previous releases style. I can eventually copy title to description.

For highlights, see changelog. The content bellow will be added to `[ANNOUNCE]`, please review:

```
Other news:
Customer Github runner is now available thanks to Paul Luse. Kinga Stefaniuk enabled it for mdadm. We are
still missing communication between Mailing List and Github.

Sadly, Intel decided to move VROC to maintenance. It means that part of the team will be disbanded
and project will be discontinued in next years. I'm leaving VROC team.
I would like to still maintain mdadm and just be here as long community as it will be possible but it is hard
to predict. I'm also actively searching for co-maintainer.
```

