### PR TITLE
tests: fix "foreign" verification for nameing tests.

### DIFF
--- a/tests/func.sh
+++ b/tests/func.sh
@@ -186,7 +186,7 @@ is_raid_foreign() {
 	# to decide if an array is foreign or local. It adds homehost if
 	# one array is local
 	hostname=$(hostname)
-	if [ `expr length "$(hostname)$name"` -lt 31 ]; then
+	if [ `expr length "$(hostname):$name"` -lt 31 ]; then
 		is_foreign="no"
 	else
 		is_foreign="yes"

--- a/tests/templates/names_template
+++ b/tests/templates/names_template
@@ -4,8 +4,6 @@ function names_create() {
 	local NAME=$2
 	local NEG_TEST=$3
 
-	is_raid_foreign $DEVNAME
-
 	if [[ -z "$NAME" ]]; then
 		mdadm -CR "$DEVNAME" -l0 -n 1 $dev0 --force
 	else
@@ -33,6 +31,10 @@ function names_verify() {
 	local WANTED_LINK="$2"
 	local WANTED_NAME="$3"
 	local EXPECTED=""
+
+	# We don't know what is saved in metadata, but we know what to expect. Therfore check if
+	# expecation would be foreign (no hostname information).
+	is_raid_foreign $WANTED_NAME
 
 	local RES="$(mdadm -D --export $DEVNODE_NAME | grep MD_DEVNAME)"
 	if [[ "$?" != "0" ]]; then


### PR DESCRIPTION
Mdadm supports DEVNODE in multiple form, we cannot trust that because it does not always reflect name in metadata. Tests are defining clear expectations- we must use them.

Do foreign verification against WANTED_NAME instead of passed DEVNODE.