### PR TITLE
platform-intel: fix buffer overflow

### DIFF
--- a/super-intel.c
+++ b/super-intel.c
@@ -7055,7 +7055,8 @@ active_arrays_by_format(char *name, char* hba, struct md_list **devlist,
 			int fd = -1;
 
 			while (dev && !is_fd_valid(fd)) {
-				char *path = xmalloc(strlen(dev->name) + strlen("/dev/") + 1);
+				char path[PATH_MAX];
+
 				num = snprintf(path, PATH_MAX, "%s%s", "/dev/", dev->name);
 				if (num > 0)
 					fd = open(path, O_RDONLY, 0);
@@ -7063,7 +7064,6 @@ active_arrays_by_format(char *name, char* hba, struct md_list **devlist,
 					pr_vrb("Cannot open %s: %s\n",
 					       dev->name, strerror(errno));
 				}
-				free(path);
 				dev = dev->next;
 			}
 			found = 0;


### PR DESCRIPTION
mdadm -C /dev/md/imsm0 -e imsm -n 2 /dev/nvme5n1 /dev/nvme4n1 -R mdadm -C /dev/md/r0d2 -l 0 -n 2 /dev/nvme5n1 /dev/nvme4n1 -R *** buffer overflow detected ***: terminated
Aborted (core dumped)

Issue is related to D_FORTIFY_SOURCE=3 flag and depends on environment, especially compiler version. In function active_arrays_by_format length of path buffer is calculated dynamically based on parameters, while PATH_MAX is used in snprintf, this is my lead to buffer overflow.

It is fixed by change dynamic length calculation, to use define PATH_MAX for path length.