### PR TITLE
CI: improve handling of failed/succussed executions.

### DIFF
--- a/.github/tools/run_mdadm_tests.sh
+++ b/.github/tools/run_mdadm_tests.sh
@@ -5,7 +5,14 @@ sudo make -j$(nproc)
 sudo make install
 sudo mdadm -Ss
 sudo ./test setup
+
+# Uncomment and adjust this to minimalize testing time for CI or test improvements.
+# --tests=test1,test2,...     Comma separated list of tests to run
+
+#sudo ./test --tests=00createnames
+
 sudo ./test --skip-broken --no-error --disable-integrity --disable-multipath --disable-linear --keep-going
+
 ret=$?
 sudo ./test cleanup
 exit $ret

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
       - '*.h'
       - 'tests/*'
       - 'test'
+      - '.github/*'
+      - '.github/workflows/*'
+      - '.github/tools/*'
 jobs:
   upstream_tests:
      if: ${{ github.repository == 'md-raid-utilities/mdadm' }}
@@ -31,23 +34,37 @@ jobs:
           vagrant halt
           vagrant status
           vagrant up
+
      - name: 'Run tests'
+       id: testing
+       continue-on-error: true
        run: |
           cd ..
           vagrant ssh -c "cd /home/vagrant/host/mdadm && .github/tools/run_mdadm_tests.sh"
+
      - name: 'Copy logs to host machine'
+       if: ${{ steps.testing.outcome == 'failure' }}
        run: |
           cd ..
           vagrant ssh -c "sudo mkdir -p /home/vagrant/host/logs && sudo mv /var/tmp/*.log /home/vagrant/host/logs"
+
      - name: "Save artifacts"
+       if: ${{ steps.testing.outcome == 'failure' }}
        uses: actions/upload-artifact@v4
        with:
          name: "Logs from failed tests"
          path: /home/ci/actions-runner/_work/mdadm/logs/*.log
+
      - name: "Clean logs"
+       if: ${{ steps.testing.outcome == 'failure' }}
        run: |
           cd ..
           sudo rm /home/ci/actions-runner/_work/mdadm/logs/*.log
+
+     - name: "Set failed"
+       if: ${{ steps.testing.outcome == 'failure' }}
+       run: exit 1
+
   cleanup:
     runs-on: self-hosted
     needs: [upstream_tests]


### PR DESCRIPTION
Currently, if error is returned by test command, execution of other
steps is aborted. In that case, continue-on-error safe artifict but
return error later and fail the job.

If executions passed, there are no artifacts to safe, therefore do not
safe them.
