### PR TITLE
super-ddf: optimize DDF header search for widely used RAID controllers

### DIFF
--- a/super-ddf.c
+++ b/super-ddf.c
@@ -5195,6 +5195,21 @@ static void default_geometry_ddf(struct supertype *st, int *level, int *layout, 
 		*layout = ddf_level_to_layout(*level);
 }
 
+static int update_super_ddf_dummy(struct supertype *st, struct mdinfo *info,
+			 enum update_opt update,
+			 char *devname, int verbose,
+			 int uuid_set, char *homehost)
+{
+	/*
+	 * A dummy update_super function is required to ensure
+	 * reliable handling of DDF metadata in mdadm.
+	 * This implementation acts as a placeholder for cases
+	 * where ss->update_super is not verified.
+	 */
+	dprintf("update_super is not implemented in DDF\n");
+	return 0;
+}
+
 struct superswitch super_ddf = {
 	.examine_super	= examine_super_ddf,
 	.brief_examine_super = brief_examine_super_ddf,
@@ -5212,6 +5227,8 @@ struct superswitch super_ddf = {
 	.match_home	= match_home_ddf,
 	.uuid_from_super= uuid_from_super_ddf,
 	.getinfo_super  = getinfo_super_ddf,
+
+	.update_super = update_super_ddf_dummy,
 
 	.avail_size	= avail_size_ddf,
 

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -75,3 +75,14 @@ char *xstrdup(const char *str)
 
 	return exit_memory_alloc_failure();
 }
+
+void *xmemalign(size_t alignment, size_t size)
+{
+	void *ptr = NULL;
+	int result = posix_memalign(&ptr, alignment, size);
+
+	if (result == 0)
+		return ptr;
+
+	return exit_memory_alloc_failure();
+}

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -9,5 +9,6 @@ void *xmalloc(size_t len);
 void *xrealloc(void *ptr, size_t len);
 void *xcalloc(size_t num, size_t size);
 char *xstrdup(const char *str);
+void *xmemalign(size_t alignment, size_t size);
 
 #endif


### PR DESCRIPTION
**Added logic to check the last 512 bytes of the device (`dsize -
  512`) first**
for the presence of the DDF header (`DDF_HEADER_MAGIC`).
  - If the header is found, the function immediately proceeds without performing a broader search.
  - Validates the magic value after reading the 512 bytes.

**Fallback to searching the last 32MB of the device**

 using the  `search_for_ddf_headers` function when the last 512 bytes do not contain the header.
  - Performs a block-by-block search to locate the DDF header within the specified region.


see also: https://github.com/md-raid-utilities/mdadm/issues/135