### PR TITLE
Including missing xmalloc header in raid6check to fix FTBFS.

### DIFF
--- a/raid6check.c
+++ b/raid6check.c
@@ -23,6 +23,8 @@
  */
 
 #include "mdadm.h"
+#include "xmalloc.h"
+
 #include <stdint.h>
 #include <sys/mman.h>
 


### PR DESCRIPTION
Hi,

with current default Debian build-flags, mdadm doesn't compile anymore because there's a missing header in raid6check.c. I've applied this in Debian some time ago and it would be nice if you could merge it.

Regards,
Daniel