### PR TITLE
udev: persist properties of MD devices after switch_root

### DIFF
--- a/udev-md-raid-arrays.rules
+++ b/udev-md-raid-arrays.rules
@@ -29,6 +29,7 @@ ENV{DEVTYPE}=="partition", ENV{MD_DEVNAME}=="*[0-9]", SYMLINK+="md/$env{MD_DEVNA
 IMPORT{builtin}="blkid"
 OPTIONS+="link_priority=100"
 OPTIONS+="watch"
+OPTIONS+="db_persist"
 ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_ENC}"
 ENV{ID_FS_USAGE}=="filesystem|other", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
 ENV{ID_FS_USAGE}=="filesystem|other", ENV{ID_FS_LABEL_ENC}=="?*", SYMLINK+="disk/by-label/$env{ID_FS_LABEL_ENC}"


### PR DESCRIPTION
dracut installs in the initrd a custom udev rule only to set this option [1]. The main purpose is that if an MD device is activated in the initrd, its properties are kept on the udev database after the transition from the initrd to the rootfs. This was added to fix detection issues when LVM is on top.

This patch would allow to remove the custom udev rule shipped by dracut (`63-md-raid-arrays.rules` is already being installed in the initrd), and it will also benefit other initrd generators that do not want to create custom udev rules.

[1] https://github.com/dracutdevs/dracut/blob/5d2bda46f4e75e85445ee4d3bd3f68bf966287b9/modules.d/90mdraid/59-persistent-storage-md.rules#L23