### PR TITLE
mdadm: fix --grow with --add for linear

### DIFF
--- a/mdadm.c
+++ b/mdadm.c
@@ -1619,7 +1619,7 @@ int main(int argc, char *argv[])
 		if (devs_found > 1 && s.raiddisks == 0 && s.level == UnSet) {
 			/* must be '-a'. */
 			if (s.size > 0 || s.chunk ||
-			    s.layout_str || s.btype != BitmapNone) {
+			    s.layout_str || s.btype != BitmapUnknown) {
 				pr_err("--add cannot be used with other geometry changes in --grow mode\n");
 				rv = 1;
 				break;


### PR DESCRIPTION
For the case mdadm --grow with --add, the s.btype should not be initialized yet, hence BitmapUnknown should be checked instead of BitmapNone.

Noted that this behaviour should only support by md-linear, which is removed from kernel, howerver, it turns out md-linear is used widely in home NAS and we're planning to reintroduce it soon.

Fixes: 581ba1341017 ("mdadm: remove bitmap file support")

PR to test Kuai's changes.