### PR TITLE
mdadm: use <linux/raid> headers

### DIFF
--- a/Create.c
+++ b/Create.c
@@ -23,8 +23,6 @@
  */
 
 #include	"mdadm.h"
-#include	"md_u.h"
-#include	"md_p.h"
 #include	"udev.h"
 #include	"xmalloc.h"
 

--- a/Detail.c
+++ b/Detail.c
@@ -23,8 +23,6 @@
  */
 
 #include	"mdadm.h"
-#include	"md_p.h"
-#include	"md_u.h"
 #include	"xmalloc.h"
 
 #include	<ctype.h>

--- a/Examine.c
+++ b/Examine.c
@@ -24,8 +24,6 @@
 
 #include	"dlink.h"
 #include	"mdadm.h"
-#include	"md_u.h"
-#include	"md_p.h"
 #include	"xmalloc.h"
 
 #if ! defined(__BIG_ENDIAN) && ! defined(__LITTLE_ENDIAN)

--- a/Grow.c
+++ b/Grow.c
@@ -30,12 +30,6 @@
 #include	<stdint.h>
 #include	<sys/wait.h>
 
-#if ! defined(__BIG_ENDIAN) && ! defined(__LITTLE_ENDIAN)
-#error no endian defined
-#endif
-#include	"md_u.h"
-#include	"md_p.h"
-
 int restore_backup(struct supertype *st,
 		   struct mdinfo *content,
 		   int working_disks,

--- a/Kill.c
+++ b/Kill.c
@@ -26,8 +26,6 @@
  */
 
 #include	"mdadm.h"
-#include	"md_u.h"
-#include	"md_p.h"
 
 int Kill(char *dev, struct supertype *st, int force, int verbose, int noexcl)
 {

--- a/Manage.c
+++ b/Manage.c
@@ -23,8 +23,6 @@
  */
 
 #include "mdadm.h"
-#include "md_u.h"
-#include "md_p.h"
 #include "udev.h"
 #include "xmalloc.h"
 

--- a/Query.c
+++ b/Query.c
@@ -23,8 +23,6 @@
  */
 
 #include	"mdadm.h"
-#include	"md_p.h"
-#include	"md_u.h"
 
 int Query(char *dev)
 {

--- a/README.md
+++ b/README.md
@@ -135,9 +135,6 @@ List of installation targets:
 
 The following targets are deprecated and should not be used:
 - `install-static`
-- `install-tcc`
-- `install-uclibc`
-- `install-klibc`
 
 # License
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -34,6 +34,7 @@ extern __off64_t lseek64 __P ((int __fd, __off64_t __offset, int __whence));
 #endif
 
 #include	<assert.h>
+#include	<asm/byteorder.h>
 #include	<sys/types.h>
 #include	<sys/stat.h>
 #include	<stdarg.h>
@@ -85,7 +86,6 @@ struct dlm_lksb {
 #endif
 
 #include	<linux/kdev_t.h>
-/*#include	<linux/fs.h> */
 #include	<sys/mount.h>
 #include	<asm/types.h>
 #include	<sys/ioctl.h>
@@ -168,59 +168,6 @@ struct dlm_lksb {
 #include	"bitmap.h"
 #include	"msg.h"
 #include	"mdadm_status.h"
-
-#include <endian.h>
-/* Redhat don't like to #include <asm/byteorder.h>, and
- * some time include <linux/byteorder/xxx_endian.h> isn't enough,
- * and there is no standard conversion function so... */
-/* And dietlibc doesn't think byteswap is ok, so.. */
-/*  #include <byteswap.h> */
-#define __mdadm_bswap_16(x) (((x) & 0x00ffU) << 8 | \
-			     ((x) & 0xff00U) >> 8)
-#define __mdadm_bswap_32(x) (((x) & 0x000000ffU) << 24 | \
-			     ((x) & 0xff000000U) >> 24 | \
-			     ((x) & 0x0000ff00U) << 8  | \
-			     ((x) & 0x00ff0000U) >> 8)
-#define __mdadm_bswap_64(x) (((x) & 0x00000000000000ffULL) << 56 | \
-			     ((x) & 0xff00000000000000ULL) >> 56 | \
-			     ((x) & 0x000000000000ff00ULL) << 40 | \
-			     ((x) & 0x00ff000000000000ULL) >> 40 | \
-			     ((x) & 0x0000000000ff0000ULL) << 24 | \
-			     ((x) & 0x0000ff0000000000ULL) >> 24 | \
-			     ((x) & 0x00000000ff000000ULL) << 8 |  \
-			     ((x) & 0x000000ff00000000ULL) >> 8)
-
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define	__cpu_to_le16(_x) (unsigned int)(_x)
-#define __cpu_to_le32(_x) (unsigned int)(_x)
-#define __cpu_to_le64(_x) (unsigned long long)(_x)
-#define	__le16_to_cpu(_x) (unsigned int)(_x)
-#define __le32_to_cpu(_x) (unsigned int)(_x)
-#define __le64_to_cpu(_x) (unsigned long long)(_x)
-
-#define	__cpu_to_be16(_x) __mdadm_bswap_16(_x)
-#define __cpu_to_be32(_x) __mdadm_bswap_32(_x)
-#define __cpu_to_be64(_x) __mdadm_bswap_64(_x)
-#define	__be16_to_cpu(_x) __mdadm_bswap_16(_x)
-#define __be32_to_cpu(_x) __mdadm_bswap_32(_x)
-#define __be64_to_cpu(_x) __mdadm_bswap_64(_x)
-#elif BYTE_ORDER == BIG_ENDIAN
-#define	__cpu_to_le16(_x) __mdadm_bswap_16(_x)
-#define __cpu_to_le32(_x) __mdadm_bswap_32(_x)
-#define __cpu_to_le64(_x) __mdadm_bswap_64(_x)
-#define	__le16_to_cpu(_x) __mdadm_bswap_16(_x)
-#define __le32_to_cpu(_x) __mdadm_bswap_32(_x)
-#define __le64_to_cpu(_x) __mdadm_bswap_64(_x)
-
-#define	__cpu_to_be16(_x) (unsigned int)(_x)
-#define __cpu_to_be32(_x) (unsigned int)(_x)
-#define __cpu_to_be64(_x) (unsigned long long)(_x)
-#define	__be16_to_cpu(_x) (unsigned int)(_x)
-#define __be32_to_cpu(_x) (unsigned int)(_x)
-#define __be64_to_cpu(_x) (unsigned long long)(_x)
-#else
-#  error "unknown endianness."
-#endif
 
 /*
  * Partially stolen from include/linux/unaligned/packed_struct.h

--- a/mdadm.h
+++ b/mdadm.h
@@ -163,8 +163,20 @@ struct dlm_lksb {
 #define GROW_SERVICE "mdadm-grow-continue"
 #endif /* GROW_SERVICE */
 
-#include	"md_u.h"
-#include	"md_p.h"
+#include	<linux/raid/md_u.h>
+#include	<linux/raid/md_p.h>
+
+/* These defines might be missing in raid headers*/
+#ifndef MD_SB_BLOCK_CONTAINER_RESHAPE
+#define MD_SB_BLOCK_CONTAINER_RESHAPE	3
+#endif
+#ifndef MD_SB_BLOCK_VOLUME
+#define MD_SB_BLOCK_VOLUME		4
+#endif
+#ifndef MD_DISK_REPLACEMENT
+#define MD_DISK_REPLACEMENT		17
+#endif
+
 #include	"bitmap.h"
 #include	"msg.h"
 #include	"mdadm_status.h"

--- a/mdadm.h
+++ b/mdadm.h
@@ -43,6 +43,7 @@ extern __off64_t lseek64 __P ((int __fd, __off64_t __offset, int __whence));
 #include	<sys/time.h>
 #include	<getopt.h>
 #include	<fcntl.h>
+#include	<ftw.h>
 #include	<stdio.h>
 #include	<errno.h>
 #include	<string.h>
@@ -189,7 +190,6 @@ struct dlm_lksb {
 			     ((x) & 0x00000000ff000000ULL) << 8 |  \
 			     ((x) & 0x000000ff00000000ULL) >> 8)
 
-#if !defined(__KLIBC__)
 #if BYTE_ORDER == LITTLE_ENDIAN
 #define	__cpu_to_le16(_x) (unsigned int)(_x)
 #define __cpu_to_le32(_x) (unsigned int)(_x)
@@ -221,7 +221,6 @@ struct dlm_lksb {
 #else
 #  error "unknown endianness."
 #endif
-#endif /* __KLIBC__ */
 
 /*
  * Partially stolen from include/linux/unaligned/packed_struct.h
@@ -1528,40 +1527,6 @@ extern void sysfsline(char *line);
 
 #if __GNUC__ < 3
 struct stat64;
-#endif
-
-#define HAVE_NFTW  we assume
-#define HAVE_FTW
-
-#ifdef __UCLIBC__
-# include <features.h>
-# ifndef __UCLIBC_HAS_LFS__
-#  define lseek64 lseek
-# endif
-# ifndef  __UCLIBC_HAS_FTW__
-#  undef HAVE_FTW
-#  undef HAVE_NFTW
-# endif
-#endif
-
-#ifdef __dietlibc__
-# undef HAVE_NFTW
-#endif
-
-#if defined(__KLIBC__)
-# undef HAVE_NFTW
-# undef HAVE_FTW
-#endif
-
-#ifndef HAVE_NFTW
-# define FTW_PHYS 1
-# ifndef HAVE_FTW
-  struct FTW {};
-# endif
-#endif
-
-#ifdef HAVE_FTW
-# include <ftw.h>
 #endif
 
 extern int add_dev(const char *name, const struct stat *stb, int flag, struct FTW *s);

--- a/mdmonitor.c
+++ b/mdmonitor.c
@@ -23,8 +23,6 @@
  */
 
 #include	"mdadm.h"
-#include	"md_p.h"
-#include	"md_u.h"
 #include	"udev.h"
 #include	"xmalloc.h"
 

--- a/super1.c
+++ b/super1.c
@@ -26,92 +26,6 @@
 #include "mdadm.h"
 #include "xmalloc.h"
 
-/*
- * The version-1 superblock :
- * All numeric fields are little-endian.
- *
- * total size: 256 bytes plus 2 per device.
- *  1K allows 384 devices.
- */
-struct mdp_superblock_1 {
-	/* constant array information - 128 bytes */
-	__u32	magic;		/* MD_SB_MAGIC: 0xa92b4efc - little endian */
-	__u32	major_version;	/* 1 */
-	__u32	feature_map;	/* 0 for now */
-	__u32	pad0;		/* always set to 0 when writing */
-
-	__u8	set_uuid[16];	/* user-space generated. */
-	char	set_name[32];	/* set and interpreted by user-space */
-
-	__u64	ctime;		/* lo 40 bits are seconds, top 24 are microseconds or 0*/
-	__u32	level;		/* -4 (multipath), -1 (linear), 0,1,4,5 */
-	__u32	layout;		/* used for raid5, raid6, raid10, and raid0 */
-	__u64	size;		/* used size of component devices, in 512byte sectors */
-
-	__u32	chunksize;	/* in 512byte sectors */
-	__u32	raid_disks;
-	union {
-		__u32	bitmap_offset;	/* sectors after start of superblock that bitmap starts
-					 * NOTE: signed, so bitmap can be before superblock
-					 * only meaningful of feature_map[0] is set.
-					 */
-
-		/* only meaningful when feature_map[MD_FEATURE_PPL] is set */
-		struct {
-			__s16 offset; /* sectors from start of superblock that ppl starts */
-			__u16 size; /* ppl size in sectors */
-		} ppl;
-	};
-
-	/* These are only valid with feature bit '4' */
-	__u32	new_level;	/* new level we are reshaping to		*/
-	__u64	reshape_position;	/* next address in array-space for reshape */
-	__u32	delta_disks;	/* change in number of raid_disks		*/
-	__u32	new_layout;	/* new layout					*/
-	__u32	new_chunk;	/* new chunk size (sectors)			*/
-	__u32	new_offset;	/* signed number to add to data_offset in new
-				 * layout.  0 == no-change.  This can be
-				 * different on each device in the array.
-				 */
-
-	/* constant this-device information - 64 bytes */
-	__u64	data_offset;	/* sector start of data, often 0 */
-	__u64	data_size;	/* sectors in this device that can be used for data */
-	__u64	super_offset;	/* sector start of this superblock */
-	union {
-		__u64	recovery_offset;/* sectors before this offset (from data_offset) have been recovered */
-		__u64	journal_tail;/* journal tail of journal device (from data_offset) */
-	};
-	__u32	dev_number;	/* permanent identifier of this  device - not role in raid */
-	__u32	cnt_corrected_read; /* number of read errors that were corrected by re-writing */
-	__u8	device_uuid[16]; /* user-space setable, ignored by kernel */
-	__u8    devflags;        /* per-device flags.  Only one defined...*/
-#define WriteMostly1    1        /* mask for writemostly flag in above */
-#define FailFast1	2        /* Device should get FailFast requests */
-	/* bad block log.  If there are any bad blocks the feature flag is set.
-	 * if offset and size are non-zero, that space is reserved and available.
-	 */
-	__u8	bblog_shift;	/* shift from sectors to block size for badblock list */
-	__u16	bblog_size;	/* number of sectors reserved for badblock list */
-	__u32	bblog_offset;	/* sector offset from superblock to bblog, signed */
-
-	/* array state information - 64 bytes */
-	__u64	utime;		/* 40 bits second, 24 bits microseconds */
-	__u64	events;		/* incremented when superblock updated */
-	__u64	resync_offset;	/* data before this offset (from data_offset) known to be in sync */
-	__u32	sb_csum;	/* checksum upto dev_roles[max_dev] */
-	__u32	max_dev;	/* size of dev_roles[] array to consider */
-	__u8	pad3[64-32];	/* set to 0 when writing */
-
-	/* device state information. Indexed by dev_number.
-	 * 2 bytes per device
-	 * Note there are no per-device state flags. State information is rolled
-	 * into the 'roles' value.  If a device is spare or faulty, then it doesn't
-	 * have a meaningful role.
-	 */
-	__u16	dev_roles[0];	/* role in array, or 0xffff for a spare, or 0xfffe for faulty */
-};
-
 #define MAX_SB_SIZE 4096
 /* bitmap super size is 256, but we round up to a sector for alignment */
 #define BM_SUPER_SIZE 512
@@ -126,40 +40,6 @@ struct misc_dev_info {
 #define MULTIPLE_PPL_AREA_SIZE_SUPER1 (1024 * 1024) /* Size of the whole
 						     * mutliple PPL area
 						     */
-/* feature_map bits */
-#define MD_FEATURE_BITMAP_OFFSET	1
-#define	MD_FEATURE_RECOVERY_OFFSET	2 /* recovery_offset is present and
-					   * must be honoured
-					   */
-#define	MD_FEATURE_RESHAPE_ACTIVE	4
-#define	MD_FEATURE_BAD_BLOCKS		8 /* badblock list is not empty */
-#define	MD_FEATURE_REPLACEMENT		16 /* This device is replacing an
-					    * active device with same 'role'.
-					    * 'recovery_offset' is also set.
-					    */
-#define	MD_FEATURE_RESHAPE_BACKWARDS	32 /* Reshape doesn't change number
-					    * of devices, but is going
-					    * backwards anyway.
-					    */
-#define	MD_FEATURE_NEW_OFFSET		64 /* new_offset must be honoured */
-#define	MD_FEATURE_BITMAP_VERSIONED	256 /* bitmap version number checked properly */
-#define	MD_FEATURE_JOURNAL		512 /* support write journal */
-#define	MD_FEATURE_PPL			1024 /* support PPL */
-#define	MD_FEATURE_MUTLIPLE_PPLS	2048 /* support for multiple PPLs */
-#define	MD_FEATURE_RAID0_LAYOUT		4096 /* layout is meaningful in RAID0 */
-#define	MD_FEATURE_ALL			(MD_FEATURE_BITMAP_OFFSET	\
-					|MD_FEATURE_RECOVERY_OFFSET	\
-					|MD_FEATURE_RESHAPE_ACTIVE	\
-					|MD_FEATURE_BAD_BLOCKS		\
-					|MD_FEATURE_REPLACEMENT		\
-					|MD_FEATURE_RESHAPE_BACKWARDS	\
-					|MD_FEATURE_NEW_OFFSET		\
-					|MD_FEATURE_BITMAP_VERSIONED	\
-					|MD_FEATURE_JOURNAL		\
-					|MD_FEATURE_PPL			\
-					|MD_FEATURE_MULTIPLE_PPLS	\
-					|MD_FEATURE_RAID0_LAYOUT	\
-					)
 
 static int role_from_sb(struct mdp_superblock_1 *sb)
 {
@@ -319,7 +199,7 @@ static int awrite(struct align_fd *afd, void *buf, int len)
 static inline unsigned int md_feature_any_ppl_on(__u32 feature_map)
 {
 	return ((__cpu_to_le32(feature_map) &
-	    (MD_FEATURE_PPL | MD_FEATURE_MUTLIPLE_PPLS)));
+	    (MD_FEATURE_PPL | MD_FEATURE_MULTIPLE_PPLS)));
 }
 
 static inline unsigned int choose_ppl_space(int chunk)
@@ -1483,7 +1363,7 @@ static int update_super1(struct supertype *st, struct mdinfo *info,
 	}
 	case UOPT_NO_PPL:
 		sb->feature_map &= ~__cpu_to_le32(MD_FEATURE_PPL |
-						   MD_FEATURE_MUTLIPLE_PPLS);
+						  MD_FEATURE_MULTIPLE_PPLS);
 		break;
 	case UOPT_DEVICESIZE:
 		if (__le64_to_cpu(sb->super_offset) >=
@@ -2643,7 +2523,7 @@ add_internal_bitmap1(struct supertype *st,
 	bms->nodes = __cpu_to_le32(st->nodes);
 	if (st->nodes)
 		sb->feature_map = __cpu_to_le32(__le32_to_cpu(sb->feature_map) |
-						MD_FEATURE_BITMAP_VERSIONED);
+						MD_FEATURE_CLUSTERED);
 	if (st->cluster_name) {
 		len = sizeof(bms->cluster_name);
 		strncpy((char *)bms->cluster_name, st->cluster_name, len);

--- a/udev.c
+++ b/udev.c
@@ -20,8 +20,6 @@
 
 #include	"mdadm.h"
 #include	"udev.h"
-#include	"md_p.h"
-#include	"md_u.h"
 #include	"xmalloc.h"
 
 #include	<sys/wait.h>


### PR DESCRIPTION
For a years we redefined these headers in mdadm. It was efficient way to handle implementation of new features, we didn't rely on kernel during compilation. It is huge mess now.

We should reuse the headers exported to integrate driver and mdadm better.  Add them and remove local headers.

This PR requires deep review and testing. @ncroxon, @XiaoNi87 I need your support on this.