### PR TITLE
mdadm: check posix name before setting name and devname

### DIFF
--- a/config.c
+++ b/config.c
@@ -208,11 +208,6 @@ static mdadm_status_t ident_check_name(const char *name, const char *prop_name, 
 		return MDADM_STATUS_ERROR;
 	}
 
-	if (!is_name_posix_compatible(name)) {
-		ident_log(prop_name, name, "Not POSIX compatible", cmdline);
-		return MDADM_STATUS_ERROR;
-	}
-
 	return MDADM_STATUS_SUCCESS;
 }
 
@@ -512,7 +507,8 @@ void arrayline(char *line)
 
 	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (w[0] == '/' || strchr(w, '=') == NULL) {
-			_ident_set_devname(&mis, w, false);
+			if (is_name_posix_compatible(basename(w)))
+				_ident_set_devname(&mis, w, false);
 		} else if (strncasecmp(w, "uuid=", 5) == 0) {
 			if (mis.uuid_set)
 				pr_err("only specify uuid once, %s ignored.\n",

--- a/mdadm.c
+++ b/mdadm.c
@@ -732,6 +732,12 @@ int main(int argc, char *argv[])
 				exit(2);
 			}
 
+			if (mode != ASSEMBLE &&
+					!is_name_posix_compatible(basename(optarg))) {
+				pr_err("%s Not POSIX compatible\n", basename(optarg));
+				exit(2);
+			}
+
 			if (ident_set_name(&ident, optarg) != MDADM_STATUS_SUCCESS)
 				exit(2);
 
@@ -1284,11 +1290,18 @@ int main(int argc, char *argv[])
 	    mode == GROW || (mode == ASSEMBLE && ! c.scan)) {
 		struct stat stb;
 		int ret;
+		char *bname = basename(devlist->devname);
 
 		if (devs_found < 1) {
 			pr_err("an md device must be given in this mode\n");
 			exit(2);
 		}
+
+		if (mode != ASSEMBLE && !is_name_posix_compatible(bname)) {
+			pr_err("%s Not POSIX compatible\n", bname);
+			exit(2);
+		}
+
 		if (ident_set_devname(&ident, devlist->devname) != MDADM_STATUS_SUCCESS)
 			exit(1);
 


### PR DESCRIPTION
It's good to has limitations for name when creating an array. But the arrays which were created before patch e2eb503bd797 (mdadm: Follow POSIX Portable Character Set) can't be assembled. So remove the POSIX check for assemble mode.

This can be reproduced:
* build mdadm without patch e2eb503bd797
* mdadm -CR /dev/md/node1:pv1 -l0 -n2 /dev/loop0 /dev/loop1
* mdadm -Ss
* build with latest mdadm, and try to assemble it.
* mdadm -A /dev/md/node1:pv1 --name node1:pv1

Fixes: e2eb503bd797 (mdadm: Follow POSIX Portable Character Set)