### PR TITLE
Rename is_name_posix_compatible to is_name_valid, allow :

### DIFF
--- a/config.c
+++ b/config.c
@@ -193,7 +193,7 @@ inline void ident_init(struct mddev_ident *ident)
  * @prop_name: the name of the property it is validated against, used for logging.
  * @cmdline: context dependent actions.
  *
- * @name must follow name's criteria, be POSIX compatible and does not have leading dot.
+ * @name must follow name's criteria, contain no forbidden characters and not have leading dot.
  */
 static mdadm_status_t ident_check_name(const char *name, const char *prop_name, const bool cmdline)
 {
@@ -208,8 +208,8 @@ static mdadm_status_t ident_check_name(const char *name, const char *prop_name, 
 		return MDADM_STATUS_ERROR;
 	}
 
-	if (!is_name_posix_compatible(name)) {
-		ident_log(prop_name, name, "Not POSIX compatible", cmdline);
+	if (!is_name_valid(name)) {
+		ident_log(prop_name, name, "Contains forbidden characters", cmdline);
 		return MDADM_STATUS_ERROR;
 	}
 

--- a/lib.c
+++ b/lib.c
@@ -472,20 +472,20 @@ bool is_alphanum(const char c)
 }
 
 /**
- * is_name_posix_compatible() - Check if name is POSIX compatible.
+ * is_name_valid() - Check if name contains disallowed characters.
  * @name: name to check.
  *
- *  POSIX portable file name character set contains ASCII letters,
- *  digits, '_', '.', and '-'. Also forbid leading '-'.
+ *  Allows name to contain only ASCII letters, digits, '_', '.', ':' and '-'.
+ *  Also forbid leading '-'.
  *  The length of the name cannot exceed NAME_MAX - 1 (ensure NULL ending).
  *
  * Return: %true on success, %false otherwise.
  */
-bool is_name_posix_compatible(const char * const name)
+bool is_name_valid(const char * const name)
 {
 	assert(name);
 
-	char allowed_symbols[] = "-_.";
+	char allowed_symbols[] = "-_.:";
 	const char *n = name;
 
 	if (!is_string_lq(name, NAME_MAX))

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -885,7 +885,7 @@ are used to add different devices).
 Set a
 .B name
 for the array. It must be
-.BR "POSIX PORTABLE NAME"
+.BR "MDADM NAME FORMAT"
 compatible and cannot be longer than 32 chars. This is effective when creating an array
 with a v1 metadata, or an external array.
 
@@ -1025,7 +1025,7 @@ is much safer.
 .TP
 .BR \-N ", " \-\-name=
 Specify the name of the array to assemble. It must be
-.BR "POSIX PORTABLE NAME"
+.BR "MDADM NAME FORMAT"
 compatible and cannot be longer than 32 chars. This must be the name
 that was specified when creating the array. It must either match
 the name stored in the superblock exactly, or it must match
@@ -2237,7 +2237,7 @@ and
 The
 .B name
 option updates the subarray name in the metadata. It must be
-.BR "POSIX PORTABLE NAME"
+.BR "MDADM NAME FORMAT"
 compatible and cannot be longer than 32 chars. If successes, new value will be respected after
 next assembly.
 
@@ -3189,8 +3189,8 @@ When
 .B \-\-incremental
 mode is used, this file gets a list of arrays currently being created.
 
-.SH POSIX PORTABLE NAME
-A valid name can only consist of characters "A-Za-z0-9.-_".
+.SH MDADM NAME FORMAT
+A valid name can only consist of characters "A-Za-z0-9.-_:".
 The name cannot start with a leading "-" and cannot exceed 255 chars.
 
 .SH DEVICE NAMES
@@ -3215,7 +3215,7 @@ can be given, or just the suffix of the second sort of name, such as
 can be given.
 
 In every style, raw name must be compatible with
-.BR "POSIX PORTABLE NAME"
+.BR "MDADM NAME FORMAT"
 and has to be no longer than 32 chars.
 
 When

--- a/mdadm.h
+++ b/mdadm.h
@@ -1675,7 +1675,7 @@ extern int check_raid(int fd, char *name);
 extern int check_partitions(int fd, char *dname,
 			    unsigned long long freesize,
 			    unsigned long long size);
-extern bool is_name_posix_compatible(const char *path);
+extern bool is_name_valid(const char *path);
 extern int fstat_is_blkdev(int fd, char *devname, dev_t *rdev);
 extern int stat_is_blkdev(char *devname, dev_t *rdev);
 


### PR DESCRIPTION
The name of this function is a lie. The POSIX Portable Character Set contains far more characters than just letters, digits and _ . and -. Notably, it contains the space character, which this function was specifically introduced to disallow.

The function also disallows the : character, which is a problem because we often add this character to device names ourselves, when we prepend the hostname. So with this check it is possible to be blocked from assembling a device under the name mdadm gave it:

mdadm --assemble /dev/md/system2:pv00 --run --uuid=8e4473bc:997208c1:da327078:0dc4d134 /dev/sda3 /dev/sdb1 mdadm: Value "system2:pv00" cannot be set as devname. Reason: Not POSIX compatible.

So, let's give this function an accurate name, and relax it to allow the : character.