### PR TITLE
mdadm: removed POSIX check

### DIFF
--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -884,10 +884,8 @@ are used to add different devices).
 .BR \-N ", " \-\-name=
 Set a
 .B name
-for the array. It must be
-.BR "POSIX PORTABLE NAME"
-compatible and cannot be longer than 32 chars. This is effective when creating an array
-with a v1 metadata, or an external array.
+for the array. It cannot be longer than 32 chars. This is effective when
+creating an array with a v1 metadata, or an external array.
 
 If name is needed but not specified, it is taken from the basename of the device
 that is being created. See
@@ -1024,11 +1022,9 @@ is much safer.
 
 .TP
 .BR \-N ", " \-\-name=
-Specify the name of the array to assemble. It must be
-.BR "POSIX PORTABLE NAME"
-compatible and cannot be longer than 32 chars. This must be the name
-that was specified when creating the array. It must either match
-the name stored in the superblock exactly, or it must match
+Specify the name of the array to assemble. It cannot be longer than 32 chars.
+This must be the name that was specified when creating the array. It must
+either match the name stored in the superblock exactly, or it must match
 with the current
 .I homehost
 prefixed to the start of the given name.
@@ -2236,10 +2232,8 @@ and
 
 The
 .B name
-option updates the subarray name in the metadata. It must be
-.BR "POSIX PORTABLE NAME"
-compatible and cannot be longer than 32 chars. If successes, new value will be respected after
-next assembly.
+option updates the subarray name in the metadata. It cannot be longer than
+32 chars. If successes, new value will be respected after next assembly.
 
 The
 .B ppl
@@ -3214,9 +3208,7 @@ can be given, or just the suffix of the second sort of name, such as
 .I home
 can be given.
 
-In every style, raw name must be compatible with
-.BR "POSIX PORTABLE NAME"
-and has to be no longer than 32 chars.
+In every style, raw name has to be no longer than 32 chars.
 
 When
 .I mdadm

--- a/super-intel.c
+++ b/super-intel.c
@@ -5630,6 +5630,17 @@ static bool imsm_is_name_allowed(struct intel_super *super, const char * const n
 		return false;
 	}
 
+	if (name[0] == '.') {
+		pr_vrb("imsm: Name \"%s\" has forbidden leading dot", name);
+		return false;
+	}
+
+	if (is_name_posix_compatible(name) == false) {
+		pr_vrb("imsm: Name \"%s\" doesn't follow POSIX portable file name character set",
+		       name);
+		return false;
+	}
+
 	for (i = 0; i < mpb->num_raid_devs; i++) {
 		struct imsm_dev *dev = get_imsm_dev(super, i);
 

--- a/tests/00confnames
+++ b/tests/00confnames
@@ -4,6 +4,10 @@ set -x -e
 # Test how <devname> is handled during Incremental assemblation with
 # config file and ARRAYLINE specified.
 
+# for native, mdadm is not limiting or checking the set of ASCI symbols that
+# can be used. It is up to user to use symbols that are not conflicting with
+# system utilities. Any problem is this area is not mdadm issue.
+
 names_create "/dev/md/name"
 local _UUID="$(mdadm -D --export /dev/md127 | grep MD_UUID | cut -d'=' -f2)"
 [[ "$_UUID" == "" ]] && echo "Cannot obtain UUID for $DEVNODE_NAME" && exit 1
@@ -41,14 +45,7 @@ mdadm -I $dev0 --config=$config
 names_verify "/dev/md4" "empty" "name"
 mdadm -S "/dev/md4"
 
-# 6. <devname> with some special symbols and locales.
-# <devname> should be ignored.
-names_make_conf $_UUID "tźż-\.,<>st+-" $config
-mdadm -I $dev0 --config=$config
-names_verify "/dev/md127" "name" "name"
-mdadm -S "/dev/md127"
-
-# 7. No <devname> set.
+# 6. No <devname> set.
 # Metadata name and default node used.
 names_make_conf $_UUID "empty" $config
 mdadm -I $dev0 --config=$config


### PR DESCRIPTION
Neil Brown in #159 pointed that mdadm should been keep in base utility style, allowing much more with no strict limitations until absolutely necessary to prevent crashes.

This view, supported with regression https://github.com/md-raid-utilities/mdadm/pull/160 caused by POSIX portable
character set requirement leads me to revert it.

Revert the POSIX portable character set verification of name and
devname. Make it IMSM only.

Fixes: #159 
Fixes: #160 
