### PR TITLE
mdadm: allow any valid minor number in md device name

### DIFF
--- a/util.c
+++ b/util.c
@@ -972,7 +972,8 @@ static bool is_devname_numbered(const char *devname, const char *pref, const int
 	if (parse_num(&val, devname + pref_len) != 0)
 		return false;
 
-	if (val > 1024)
+	/* Allow any number that represents a valid minor number */
+	if (val >= (1 << 20))
 		return false;
 
 	return true;


### PR DESCRIPTION
Since 25aa732 ("mdadm: numbered names verification"), it is not possible any more to create arrays /dev/md${N} with N >= 127. The limit has later been increased to 1024, which is also artificial. The error message printed by mdadm is misleading, as the problem is not POSIX compatibility here.

    # mdadm -C -v /dev/md9999 --name=foo -l1 -n2 /dev/loop0 /dev/loop1
    mdadm: Value "/dev/md9999" cannot be set as devname. Reason: Not POSIX compatible.

Given that mdadm creates an array with minor number ${N} if the argument is /dev/md${N}, the natural limit for the number is the highest minor number available, which is (1 << MINORBITS) with MINORBITS=20 on Linux.


I'm aware that the error message above will go away with #165. I believe that this has some merit in its own right (be it only because of the name / minor number equivalence), therefore I'm proposing it nonetheless.
