### PR TITLE
test: 02r5grow not working properly

### DIFF
--- a/tests/02r5grow
+++ b/tests/02r5grow
@@ -41,13 +41,14 @@ check wait
 check state UUU
 check chunk 32
 
-mdadm $md0 --grow --chunk=64
-check reshape
+mdadm $md0 --grow --size max
+check resync
 check wait
-check chunk 64
+check chunk 32
+testdrv $md0 2 $mdsize0 32
 
 mdadm -S $md0
 mdadm -A $md0 $dev1 $dev2 $dev3
 check state UUU
-check chunk 64
+check chunk 32
 mdadm -S $md0


### PR DESCRIPTION
The test states it will create a small raid5 array, make it larger. Then make it smaller. It doesn't do that. The last part of the test does not do a grow but a chunk change. The change is to do a grow again (with a different chunk size)