### PR TITLE
mdadm/assemble: Don't stop array after creating it

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -1570,8 +1570,6 @@ try_again:
 				goto try_again;
 			goto out;
 		}
-		/* just incase it was started but has no content */
-		ioctl(mdfd, STOP_ARRAY, NULL);
 	}
 
 	if (content != &info) {


### PR DESCRIPTION
It stops the array which is just created. From the comment it wants to stop the array if it has no content. But it hasn't added member disks, so it's a clean array. It's meaningless to do it.