### PR TITLE
mdadm: use lseek consistently - WIP

### DIFF
--- a/mdadm.h
+++ b/mdadm.h
@@ -24,15 +24,9 @@
 
 #define	_GNU_SOURCE
 #define _FILE_OFFSET_BITS 64
-#include	<unistd.h>
-#ifdef __GLIBC__
-extern __off64_t lseek64 __P ((int __fd, __off64_t __offset, int __whence));
-#elif !defined(lseek64)
-# if defined(__NO_STAT64) || __WORDSIZE != 32
-# define lseek64 lseek
-# endif
-#endif
+#define  __USE_LARGEFILE64 1
 
+#include	<unistd.h>
 #include	<assert.h>
 #include	<asm/byteorder.h>
 #include	<sys/types.h>

--- a/raid6check.c
+++ b/raid6check.c
@@ -212,9 +212,12 @@ int autorepair(int *disk, unsigned long long start, int chunk_size,
 		for(j = 0; j < (chunk_size >> CHECK_PAGE_BITS); j++) {
 			if(page_to_write[j] == 1) {
 				int slot = block_index_for_slot[disk[j]];
-				lseek64(source[slot], offsets[slot] + start * chunk_size + j * CHECK_PAGE_SIZE, SEEK_SET);
+				lseek(source[slot],
+				      offsets[slot] + start * chunk_size +
+				      j * CHECK_PAGE_SIZE, SEEK_SET);
 				write_res += write(source[slot],
-						   blocks[disk[j]] + j * CHECK_PAGE_SIZE,
+						   blocks[disk[j]] +
+						   j * CHECK_PAGE_SIZE,
 						   CHECK_PAGE_SIZE);
 			}
 		}
@@ -287,16 +290,14 @@ int manual_repair(int chunk_size, int syndrome_disks,
 	int write_res1, write_res2;
 	off64_t seek_res;
 
-	seek_res = lseek64(source[fd1],
-			   offsets[fd1] + start * chunk_size, SEEK_SET);
+	seek_res = lseek(source[fd1], offsets[fd1] + start * chunk_size, SEEK_SET);
 	if (seek_res < 0) {
 		fprintf(stderr, "lseek failed for failed_disk1\n");
 		return -1;
 	}
 	write_res1 = write(source[fd1], blocks[failed_slot1], chunk_size);
 
-	seek_res = lseek64(source[fd2],
-			   offsets[fd2] + start * chunk_size, SEEK_SET);
+	seek_res = lseek(source[fd2], offsets[fd2] + start * chunk_size, SEEK_SET);
 	if (seek_res < 0) {
 		fprintf(stderr, "lseek failed for failed_disk2\n");
 		return -1;
@@ -380,7 +381,7 @@ int check_stripes(struct mdinfo *info, int *source, unsigned long long *offsets,
 			goto exitCheck;
 		}
 		for (i = 0 ; i < raid_disks ; i++) {
-			off64_t seek_res = lseek64(source[i], offsets[i] + start * chunk_size,
+			off64_t seek_res = lseek(source[i], offsets[i] + start * chunk_size,
 						   SEEK_SET);
 			if (seek_res < 0) {
 				fprintf(stderr, "lseek to source %d failed\n", i);

--- a/restripe.c
+++ b/restripe.c
@@ -583,8 +583,7 @@ int save_stripes(int *source, unsigned long long *offsets,
 				       raid_disks, level, layout);
 			if (dnum < 0) abort();
 			if (source[dnum] < 0 ||
-			    lseek64(source[dnum],
-				    offsets[dnum] + offset, 0) < 0 ||
+			    lseek(source[dnum], offsets[dnum] + offset, 0) < 0 ||
 			    read(source[dnum], buf+disk * chunk_size,
 				 chunk_size) != chunk_size) {
 				if (failed <= 2) {
@@ -756,7 +755,7 @@ int restore_stripes(int *dest, unsigned long long *offsets,
 					   raid_disks, level, layout);
 			if (src_buf == NULL) {
 				/* read from file */
-				if (lseek64(source, read_offset, 0) !=
+				if (lseek(source, read_offset, 0) !=
 					 (off64_t)read_offset) {
 					rv = -1;
 					goto abort;
@@ -818,8 +817,7 @@ int restore_stripes(int *dest, unsigned long long *offsets,
 		}
 		for (i=0; i < raid_disks ; i++)
 			if (dest[i] >= 0) {
-				if (lseek64(dest[i],
-					 offsets[i]+offset, 0) < 0) {
+				if (lseek(dest[i], offsets[i]+offset, 0) < 0) {
 					rv = -1;
 					goto abort;
 				}
@@ -868,7 +866,7 @@ int test_stripes(int *source, unsigned long long *offsets,
 		int disk;
 
 		for (i = 0 ; i < raid_disks ; i++) {
-			if ((lseek64(source[i], offsets[i]+start, 0) < 0) ||
+			if ((lseek(source[i], offsets[i]+start, 0) < 0) ||
 			    (read(source[i], stripes[i], chunk_size) !=
 			     chunk_size)) {
 				free(q);

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -815,7 +815,7 @@ static int load_ddf_header(int fd, unsigned long long lba,
 	if (lba >= size-1)
 		return 0;
 
-	if (lseek64(fd, lba << 9, 0) == -1L)
+	if (lseek(fd, lba << 9, 0) == -1L)
 		return 0;
 
 	if (read(fd, hdr, 512) != 512)
@@ -868,7 +868,7 @@ static void *load_section(int fd, struct ddf_super *super, void *buf,
 	else
 		offset += be64_to_cpu(super->active->secondary_lba);
 
-	if ((unsigned long long)lseek64(fd, offset << 9, 0) != (offset << 9)) {
+	if ((unsigned long long)lseek(fd, offset << 9, 0) != (offset << 9)) {
 		if (dofree)
 			free(buf);
 		return NULL;
@@ -932,8 +932,8 @@ static int search_for_ddf_headers(int fd, char *devname,
 		if (search_end - pos < SEARCH_BLOCK_SIZE)
 			bytes_block_to_read = search_end - pos;
 
-		if (lseek64(fd, pos, SEEK_SET) < 0) {
-			pr_err("lseek64 for %s failed %d:%s\n",
+		if (lseek(fd, pos, SEEK_SET) < 0) {
+			pr_err("lseek for %s failed %d:%s\n",
 				fd2devnm(fd), errno, strerror(errno));
 			result = 2;
 			goto cleanup;
@@ -984,7 +984,7 @@ static int load_ddf_headers(int fd, struct ddf_super *super, char *devname)
 	get_dev_size(fd, NULL, &dsize);
 
 	/* Check the last 512 bytes for the DDF header. */
-	if (lseek64(fd, dsize - 512, SEEK_SET) == -1L) {
+	if (lseek(fd, dsize - 512, SEEK_SET) == -1L) {
 		if (devname) {
 			pr_err("Cannot seek to last 512 bytes on %s: %s\n",
 			       devname, strerror(errno));
@@ -1019,7 +1019,7 @@ static int load_ddf_headers(int fd, struct ddf_super *super, char *devname)
 		}
 
 		/* Seek to the found position */
-		if (lseek64(fd, ddfpos, SEEK_SET) == -1L) {
+		if (lseek(fd, ddfpos, SEEK_SET) == -1L) {
 			if (devname) {
 				pr_err("Cannot seek to anchor block on %s\n",
 					devname);
@@ -1849,7 +1849,7 @@ static int copy_metadata_ddf(struct supertype *st, int from, int to)
 	if (!get_dev_size(from, NULL, &dsize))
 		goto err;
 
-	if (lseek64(from, dsize - 512, 0) == -1L)
+	if (lseek(from, dsize - 512, 0) == -1L)
 		goto err;
 
 	if (read(from, buf, 512) != 512)
@@ -1870,7 +1870,7 @@ static int copy_metadata_ddf(struct supertype *st, int from, int to)
 
 	bytes = dsize - offset;
 
-	if (lseek64(from, offset, 0) == -1L || lseek64(to, offset, 0) == -1L)
+	if (lseek(from, offset, 0) == -1L || lseek(to, offset, 0) == -1L)
 		goto err;
 
 	while (written < bytes) {
@@ -3132,7 +3132,7 @@ static int __write_ddf_structure(struct dl *d, struct ddf_super *ddf, __u8 type)
 	header->openflag = 1;
 	header->crc = calc_crc(header, 512);
 
-	if (lseek64(fd, sector << 9, 0) == -1L)
+	if (lseek(fd, sector << 9, 0) == -1L)
 		goto out;
 
 	if (write(fd, header, 512) < 0)
@@ -3199,7 +3199,7 @@ out:
 	header->openflag = 0;
 	header->crc = calc_crc(header, 512);
 
-	if (lseek64(fd, sector << 9, 0) == -1L)
+	if (lseek(fd, sector << 9, 0) == -1L)
 		return 0;
 
 	if (write(fd, header, 512) < 0)
@@ -3254,7 +3254,7 @@ static int _write_super_to_disk(struct ddf_super *ddf, struct dl *d)
 	if (!__write_ddf_structure(d, ddf, DDF_HEADER_SECONDARY))
 		return 0;
 
-	if (lseek64(fd, (size - 1) * 512, SEEK_SET) == -1L)
+	if (lseek(fd, (size - 1) * 512, SEEK_SET) == -1L)
 		return 0;
 
 	if (write(fd, &ddf->anchor, 512) < 0)
@@ -4050,7 +4050,7 @@ static int store_super_ddf(struct supertype *st, int fd)
 
 	buf = xmemalign(SEARCH_BLOCK_SIZE, SEARCH_REGION_SIZE);
 	memset(buf, 0, SEARCH_REGION_SIZE);
-	if (lseek64(fd, dsize - SEARCH_REGION_SIZE, 0) == -1L) {
+	if (lseek(fd, dsize - SEARCH_REGION_SIZE, 0) == -1L) {
 		free(buf);
 		return 1;
 	}

--- a/super-intel.c
+++ b/super-intel.c
@@ -3230,7 +3230,7 @@ static int read_imsm_migr_rec(int fd, struct intel_super *super)
 	unsigned long long dsize;
 
 	get_dev_size(fd, NULL, &dsize);
-	if (lseek64(fd, dsize - (sector_size*MIGR_REC_SECTOR_POSITION),
+	if (lseek(fd, dsize - (sector_size*MIGR_REC_SECTOR_POSITION),
 		   SEEK_SET) < 0) {
 		pr_err("Cannot seek to anchor block: %s\n",
 		       strerror(errno));
@@ -3421,7 +3421,7 @@ static int write_imsm_migr_rec(struct supertype *st)
 			continue;
 
 		get_dev_size(sd->fd, NULL, &dsize);
-		if (lseek64(sd->fd, dsize - (MIGR_REC_SECTOR_POSITION *
+		if (lseek(sd->fd, dsize - (MIGR_REC_SECTOR_POSITION *
 		    sector_size),
 		    SEEK_SET) < 0) {
 			pr_err("Cannot seek to anchor block: %s\n",
@@ -4591,7 +4591,7 @@ static int load_imsm_mpb(int fd, struct intel_super *super, char *devname)
 		return 1;
 	}
 
-	if (lseek64(fd, dsize - (sector_size * 2), SEEK_SET) < 0) {
+	if (lseek(fd, dsize - (sector_size * 2), SEEK_SET) < 0) {
 		if (devname)
 			pr_err("Cannot seek to anchor block on %s: %s\n",
 			       devname, strerror(errno));
@@ -4660,7 +4660,7 @@ static int load_imsm_mpb(int fd, struct intel_super *super, char *devname)
 	}
 
 	/* read the extended mpb */
-	if (lseek64(fd, dsize - (sector_size * (2 + sectors)), SEEK_SET) < 0) {
+	if (lseek(fd, dsize - (sector_size * (2 + sectors)), SEEK_SET) < 0) {
 		if (devname)
 			pr_err("Cannot seek to extended mpb on %s: %s\n",
 			       devname, strerror(errno));
@@ -6164,7 +6164,7 @@ static int add_to_super_imsm(struct supertype *st, mdu_disk_info_t *dk,
 	/* clear migr_rec when adding disk to container */
 	memset(super->migr_rec_buf, 0, MIGR_REC_BUF_SECTORS * MAX_SECTOR_SIZE);
 
-	if (lseek64(fd, (size - MIGR_REC_SECTOR_POSITION * member_sector_size), SEEK_SET) >= 0) {
+	if (lseek(fd, (size - MIGR_REC_SECTOR_POSITION * member_sector_size), SEEK_SET) >= 0) {
 		unsigned int nbytes = MIGR_REC_BUF_SECTORS * member_sector_size;
 
 		if ((unsigned int)write(fd, super->migr_rec_buf, nbytes) != nbytes)
@@ -6387,7 +6387,7 @@ static int write_super_imsm(struct supertype *st, int doclose)
 			unsigned long long dsize;
 
 			get_dev_size(d->fd, NULL, &dsize);
-			if (lseek64(d->fd, dsize - sector_size,
+			if (lseek(d->fd, dsize - sector_size,
 			    SEEK_SET) >= 0) {
 				if ((unsigned int)write(d->fd,
 				    super->migr_rec_buf,
@@ -6470,7 +6470,7 @@ static int write_ppl_header(unsigned long long ppl_sector, int fd, void *buf)
 
 	ppl_hdr->checksum = __cpu_to_le32(~crc32c_le(~0, buf, PPL_HEADER_SIZE));
 
-	if (lseek64(fd, ppl_sector * 512, SEEK_SET) < 0) {
+	if (lseek(fd, ppl_sector * 512, SEEK_SET) < 0) {
 		ret = -errno;
 		perror("Failed to seek to PPL header location");
 		return ret;
@@ -6564,7 +6564,7 @@ static int validate_ppl_imsm(struct supertype *st, struct mdinfo *info,
 
 		dprintf("Checking potential PPL at offset: %llu\n", ppl_offset);
 
-		if (lseek64(d->fd, info->ppl_sector * 512 + ppl_offset,
+		if (lseek(d->fd, info->ppl_sector * 512 + ppl_offset,
 			    SEEK_SET) < 0) {
 			perror("Failed to seek to PPL header location");
 			ret = -1;
@@ -9089,7 +9089,7 @@ static int store_imsm_mpb(int fd, struct imsm_super *mpb)
 		sectors = mpb_sectors(mpb, sector_size) - 1;
 
 		/* write the extended mpb to the sectors preceeding the anchor */
-		if (lseek64(fd, dsize - (sector_size * (2 + sectors)),
+		if (lseek(fd, dsize - (sector_size * (2 + sectors)),
 		   SEEK_SET) < 0)
 			return 1;
 
@@ -9099,7 +9099,7 @@ static int store_imsm_mpb(int fd, struct imsm_super *mpb)
 	}
 
 	/* first block is stored on second to last sector of the disk */
-	if (lseek64(fd, dsize - (sector_size * 2), SEEK_SET) < 0)
+	if (lseek(fd, dsize - (sector_size * 2), SEEK_SET) < 0)
 		return 1;
 
 	if ((unsigned int)write(fd, buf, sector_size) != sector_size)
@@ -11282,7 +11282,7 @@ int recover_backup_imsm(struct supertype *st, struct mdinfo *info)
 			skipped_disks++;
 			continue;
 		}
-		if (lseek64(dl_disk->fd, read_offset, SEEK_SET) < 0) {
+		if (lseek(dl_disk->fd, read_offset, SEEK_SET) < 0) {
 			pr_err("Cannot seek to block: %s\n",
 			       strerror(errno));
 			skipped_disks++;
@@ -11294,7 +11294,7 @@ int recover_backup_imsm(struct supertype *st, struct mdinfo *info)
 			skipped_disks++;
 			continue;
 		}
-		if (lseek64(dl_disk->fd, write_offset, SEEK_SET) < 0) {
+		if (lseek(dl_disk->fd, write_offset, SEEK_SET) < 0) {
 			pr_err("Cannot seek to block: %s\n",
 			       strerror(errno));
 			skipped_disks++;
@@ -12776,7 +12776,7 @@ static int imsm_manage_reshape(
 		unsigned long long dsize;
 
 		get_dev_size(d->fd, NULL, &dsize);
-		if (lseek64(d->fd, dsize - MIGR_REC_SECTOR_POSITION*sector_size,
+		if (lseek(d->fd, dsize - MIGR_REC_SECTOR_POSITION*sector_size,
 			    SEEK_SET) >= 0) {
 			if ((unsigned int)write(d->fd, super->migr_rec_buf,
 			    MIGR_REC_BUF_SECTORS*sector_size) !=
@@ -12932,7 +12932,7 @@ static int validate_internal_bitmap_for_drive(struct supertype *st,
 		}
 	}
 
-	if (lseek64(fd, offset * super->sector_size, SEEK_SET) < 0)
+	if (lseek(fd, offset * super->sector_size, SEEK_SET) < 0)
 		goto abort;
 	if (read(fd, read_buf, IMSM_BITMAP_HEADER_SIZE) !=
 	    IMSM_BITMAP_HEADER_SIZE)
@@ -13050,7 +13050,7 @@ static int locate_bitmap_imsm(struct supertype *st, int fd, int node_num)
 	offset = get_bitmap_header_sector(super, super->current_vol);
 	dprintf("bitmap header offset is %llu\n", offset);
 
-	lseek64(fd, offset << 9, 0);
+	lseek(fd, offset << 9, 0);
 
 	return 0;
 }
@@ -13104,7 +13104,7 @@ static int write_init_bitmap_imsm(struct supertype *st, int fd,
 		return -1;
 	memset(buf, 0xFF, MAX_SECTOR_SIZE);
 	offset = get_bitmap_sector(super, vol_idx);
-	lseek64(fd, offset << 9, 0);
+	lseek(fd, offset << 9, 0);
 	while (written < IMSM_BITMAP_AREA_SIZE) {
 		to_write = IMSM_BITMAP_AREA_SIZE - written;
 		if (to_write > MAX_SECTOR_SIZE)

--- a/super0.c
+++ b/super0.c
@@ -332,12 +332,12 @@ static int copy_metadata0(struct supertype *st, int from, int to)
 
 	offset *= 512;
 
-	if (lseek64(from, offset, 0) < 0LL)
+	if (lseek(from, offset, 0) < 0LL)
 		goto err;
 	if (read(from, buf, bufsize) != bufsize)
 		goto err;
 
-	if (lseek64(to, offset, 0) < 0LL)
+	if (lseek(to, offset, 0) < 0LL)
 		goto err;
 	super = buf;
 	if (super->md_magic != MD_SB_MAGIC ||
@@ -895,7 +895,7 @@ static int store_super0(struct supertype *st, int fd)
 		offset = dsize/512 - 8*2;
 		offset &= ~(4*2-1);
 		offset *= 512;
-		if (lseek64(fd, offset, 0)< 0LL)
+		if (lseek(fd, offset, 0) < 0LL)
 			ret = 3;
 		else if (write(fd, st->other, 1024) != 1024)
 			ret = 4;
@@ -910,7 +910,7 @@ static int store_super0(struct supertype *st, int fd)
 
 	offset *= 512;
 
-	if (lseek64(fd, offset, 0)< 0LL)
+	if (lseek(fd, offset, 0) < 0LL)
 		return 3;
 
 	if (write(fd, super, sizeof(*super)) != sizeof(*super))
@@ -1064,7 +1064,7 @@ static int load_super0(struct supertype *st, int fd, char *devname)
 
 	offset *= 512;
 
-	if (lseek64(fd, offset, 0)< 0LL) {
+	if (lseek(fd, offset, 0) < 0LL) {
 		if (devname)
 			pr_err("Cannot seek to superblock on %s: %s\n",
 				devname, strerror(errno));
@@ -1249,7 +1249,7 @@ static int locate_bitmap0(struct supertype *st, int fd, int node_num)
 
 	offset += MD_SB_BYTES;
 
-	if (lseek64(fd, offset, 0) < 0)
+	if (lseek(fd, offset, 0) < 0)
 		return -1;
 	return 0;
 }
@@ -1275,7 +1275,7 @@ static int write_bitmap0(struct supertype *st, int fd, enum bitmap_update update
 
 	offset *= 512;
 
-	if (lseek64(fd, offset + 4096, 0)< 0LL)
+	if (lseek(fd, offset + 4096, 0) < 0LL)
 		return 3;
 
 	if (posix_memalign(&buf, 4096, 4096))

--- a/super1.c
+++ b/super1.c
@@ -628,7 +628,7 @@ static int copy_metadata1(struct supertype *st, int from, int to)
 		goto err;
 	}
 
-	if (lseek64(from, sb_offset << 9, 0) < 0LL)
+	if (lseek(from, sb_offset << 9, 0) < 0LL)
 		goto err;
 	if (read(from, buf, bufsize) != bufsize)
 		goto err;
@@ -642,7 +642,7 @@ static int copy_metadata1(struct supertype *st, int from, int to)
 	    calc_sb_1_csum(sb) != super.sb_csum)
 		goto err;
 
-	if (lseek64(to, sb_offset << 9, 0) < 0LL)
+	if (lseek(to, sb_offset << 9, 0) < 0LL)
 		goto err;
 	if (write(to, buf, bufsize) != bufsize)
 		goto err;
@@ -658,9 +658,9 @@ static int copy_metadata1(struct supertype *st, int from, int to)
 
 		bitmap_offset += (int32_t)__le32_to_cpu(super.bitmap_offset);
 
-		if (lseek64(from, bitmap_offset<<9, 0) < 0)
+		if (lseek(from, bitmap_offset<<9, 0) < 0)
 			goto err;
-		if (lseek64(to, bitmap_offset<<9, 0) < 0)
+		if (lseek(to, bitmap_offset<<9, 0) < 0)
 			goto err;
 
 		for (written = 0; written < bytes ; ) {
@@ -699,9 +699,9 @@ static int copy_metadata1(struct supertype *st, int from, int to)
 
 		bb_offset += (int32_t)__le32_to_cpu(super.bblog_offset);
 
-		if (lseek64(from, bb_offset<<9, 0) < 0)
+		if (lseek(from, bb_offset<<9, 0) < 0)
 			goto err;
-		if (lseek64(to, bb_offset<<9, 0) < 0)
+		if (lseek(to, bb_offset<<9, 0) < 0)
 			goto err;
 
 		for (written = 0; written < bytes ; ) {
@@ -803,7 +803,7 @@ static int examine_badblocks_super1(struct supertype *st, int fd, char *devname)
 	offset = __le64_to_cpu(sb->super_offset) +
 		(int)__le32_to_cpu(sb->bblog_offset);
 	offset <<= 9;
-	if (lseek64(fd, offset, 0) < 0) {
+	if (lseek(fd, offset, 0) < 0) {
 		pr_err("Cannot seek to bad-blocks list\n");
 		free(bbl);
 		return 1;
@@ -1701,7 +1701,7 @@ static int store_super1(struct supertype *st, int fd)
 		abort();
 	}
 
-	if (lseek64(fd, sb_offset << 9, 0)< 0LL)
+	if (lseek(fd, sb_offset << 9, 0) < 0LL)
 		return 3;
 
 	sbsize = ROUND_UP(sizeof(*sb) + 2 * __le32_to_cpu(sb->max_dev), 512);
@@ -1770,7 +1770,7 @@ static int write_init_ppl1(struct supertype *st, struct mdinfo *info, int fd)
 						      sizeof(sb->set_uuid)));
 	ppl_hdr->checksum = __cpu_to_le32(~crc32c_le(~0, buf, PPL_HEADER_SIZE));
 
-	if (lseek64(fd, info->ppl_sector * 512, SEEK_SET) < 0) {
+	if (lseek(fd, info->ppl_sector * 512, SEEK_SET) < 0) {
 		ret = errno;
 		perror("Failed to seek to PPL header location");
 	}
@@ -1815,7 +1815,7 @@ static int write_empty_r5l_meta_block(struct supertype *st, int fd)
 	crc = crc32c_le(crc, (void *)mb, META_BLOCK_SIZE);
 	mb->checksum = crc;
 
-	if (lseek64(fd, __le64_to_cpu(sb->data_offset) * 512, 0) < 0LL) {
+	if (lseek(fd, __le64_to_cpu(sb->data_offset) * 512, 0) < 0LL) {
 		pr_err("cannot seek to offset of the meta block\n");
 		goto fail_to_write;
 	}
@@ -2184,7 +2184,7 @@ static int load_super1(struct supertype *st, int fd, char *devname)
 		return -EINVAL;
 	}
 
-	if (lseek64(fd, sb_offset << 9, 0)< 0LL) {
+	if (lseek(fd, sb_offset << 9, 0) < 0LL) {
 		if (devname)
 			pr_err("Cannot seek to superblock on %s: %s\n",
 				devname, strerror(errno));
@@ -2569,7 +2569,7 @@ static int locate_bitmap1(struct supertype *st, int fd, int node_num)
 	}
 	if (mustfree)
 		free(sb);
-	if (lseek64(fd, offset<<9, 0) < 0) {
+	if (lseek(fd, offset<<9, 0) < 0) {
 		pr_err("lseek fails\n");
 		ret = -1;
 	}

--- a/swap_super.c
+++ b/swap_super.c
@@ -16,7 +16,7 @@
 
 #define MD_NEW_SIZE_SECTORS(x)		((x & ~(MD_RESERVED_SECTORS - 1)) - MD_RESERVED_SECTORS)
 
-extern long long lseek64(int, long long, int);
+#define  __USE_LARGEFILE64 1
 
 int main(int argc, char *argv[])
 {
@@ -38,10 +38,9 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	offset = MD_NEW_SIZE_SECTORS(size) * 512LL;
-	if (lseek64(fd, offset, 0) < 0LL) {
-		perror("lseek64");
+	if (lseek(fd, offset, 0) < 0LL)
 		exit(1);
-	}
+
 	if (read(fd, super, 4096) != 4096) {
 		perror("read");
 		exit(1);
@@ -68,10 +67,9 @@ int main(int argc, char *argv[])
 		super[32*4+10*4 +i] = t;
 	}
 
-	if (lseek64(fd, offset, 0) < 0LL) {
-		perror("lseek64");
+	if (lseek(fd, offset, 0) < 0LL)
 		exit(1);
-	}
+
 	if (write(fd, super, 4096) != 4096) {
 		perror("write");
 		exit(1);

--- a/util.c
+++ b/util.c
@@ -2456,7 +2456,7 @@ int zero_disk_range(int fd, unsigned long long sector, size_t count)
 		return -1;
 	}
 
-	if (lseek64(fd, sector * 512, SEEK_SET) < 0) {
+	if (lseek(fd, sector * 512, SEEK_SET) < 0) {
 		ret = -errno;
 		pr_err("Failed to seek offset for zeroing\n");
 		goto out;


### PR DESCRIPTION
mdadm used both lseek and lseek64 for legacy reasons. These days, we just need to configure __USE_LARGEFILE64 macro. Fixing this issue enables musl compilation.

Add macro, and change all lseek64 to lseek. Fix style issues in these lines.

Fixes: #76 