### PR TITLE
mdcheck fixes

### DIFF
--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -172,5 +172,6 @@ do
 		systemctl stop mdcheck_continue.timer
 		exit 0;
 	fi
-	sleep 220
+	sleep 220 &
+	wait $!
 done

--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -66,15 +66,40 @@ shift
 
 # We need a temp file occasionally...
 tmp=/var/lib/mdcheck/.md-check-$$
-trap 'rm -f "$tmp"' 0 2 3 15
+cnt=0
 
+cleanup() {
+    # We've waited, and there are still checks running.
+    # Time to stop them.
+    for i in `eval echo {1..$cnt}`
+    do
+	eval fl=\$MD_${i}_fl
+	eval sys=\$MD_${i}_sys
+	eval dev=\$MD_${i}_dev
+
+	if [ -z "$fl" ]; then continue; fi
+
+	if [ "`cat $sys/md/sync_action`" != 'check' ]
+	then
+	    eval MD_${i}_fl=
+	    rm -f $fl
+	    continue;
+	fi
+	echo idle > $sys/md/sync_action
+	cat $sys/md/sync_min > $fl
+	logger -p daemon.info pause checking $dev at `cat $fl`
+    done
+    rm -f "$tmp"
+}
+
+trap 'exit 129' 2 3 15
+trap 'cleanup' 0
 
 # firstly, clean out really old state files
 mkdir -p /var/lib/mdcheck
 find /var/lib/mdcheck -name "MD_UUID*" -type f -mtime +180 -exec rm {} \;
 
 # Now look at each md device.
-cnt=0
 for dev in /dev/md?*
 do
 	[ -e "$dev" ] || continue
@@ -148,25 +173,4 @@ do
 		exit 0;
 	fi
 	sleep 220
-done
-
-# We've waited, and there are still checks running.
-# Time to stop them.
-for i in `eval echo {1..$cnt}`
-do
-	eval fl=\$MD_${i}_fl
-	eval sys=\$MD_${i}_sys
-	eval dev=\$MD_${i}_dev
-
-	if [ -z "$fl" ]; then continue; fi
-
-	if [ "`cat $sys/md/sync_action`" != 'check' ]
-	then
-		eval MD_${i}_fl=
-		rm -f $fl
-		continue;
-	fi
-	echo idle > $sys/md/sync_action
-	cat $sys/md/sync_min > $fl
-	logger -p daemon.info pause checking $dev at `cat $fl`
 done

--- a/systemd/mdcheck_continue.service
+++ b/systemd/mdcheck_continue.service
@@ -11,6 +11,6 @@ ConditionPathExistsGlob=/var/lib/mdcheck/MD_UUID_*
 Documentation=man:mdadm(8)
 
 [Service]
-Type=oneshot
+Type=simple
 Environment="MDADM_CHECK_DURATION=6 hours"
 ExecStart=/usr/share/mdadm/mdcheck --continue --duration ${MDADM_CHECK_DURATION}

--- a/systemd/mdcheck_continue.timer
+++ b/systemd/mdcheck_continue.timer
@@ -9,7 +9,7 @@
 Description=MD array scrubbing - continuation
 
 [Timer]
-OnCalendar= 1:05:00
+OnCalendar= 1:00:00
 
 [Install]
 WantedBy= mdmonitor.service

--- a/systemd/mdcheck_start.service
+++ b/systemd/mdcheck_start.service
@@ -11,6 +11,6 @@ Wants=mdcheck_continue.timer
 Documentation=man:mdadm(8)
 
 [Service]
-Type=oneshot
+Type=simple
 Environment="MDADM_CHECK_DURATION=6 hours"
 ExecStart=/usr/share/mdadm/mdcheck --duration ${MDADM_CHECK_DURATION}

--- a/systemd/mdcheck_start.timer
+++ b/systemd/mdcheck_start.timer
@@ -9,7 +9,7 @@
 Description=MD array scrubbing
 
 [Timer]
-OnCalendar=Sun *-*-1..7 1:00:00
+OnCalendar=Sun *-*-1..7 1:05:00
 
 [Install]
 WantedBy= mdmonitor.service


### PR DESCRIPTION
This set fixes a few issues I've found with the `mdcheck_start` and `mdcheck_continue` systemd units.

- `systemctl start` hangs for these units until the check has finished, or ctrl-c is pressed.
- `systemctl stop` for these units may also hang for several minutes while the `mdcheck` script is executing `sleep`
- when these units are stopped with `systemctl stop`, the actual check in the kernel continues to run. Subsequent (re)starting these units has no effect because they see the kernel check already running.
- a check that has not been finished for an entire month (perhaps due to downtime) will be restarted from position 0 rather than picked up.
