### PR TITLE
More mdcheck fixes: rework mdcheck service logic

### DIFF
--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -129,7 +129,7 @@ do
 		logger -p daemon.info mdcheck continue checking $dev from $start
 	fi
 
-	cnt=$[cnt+1]
+	: "$((cnt+=1))"
 	eval MD_${cnt}_fl=\$fl
 	eval MD_${cnt}_sys=\$sys
 	eval MD_${cnt}_dev=\$dev

--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -37,6 +37,16 @@
 # Use "mdcheck --restart" to remove these markers and re-enable checking
 # all arrays.
 
+# If the script is run from systemd, simply write to the journal on stderr.
+# Otherwise, use logger.
+log() {
+    if [[ "$INVOCATION_ID" ]]; then
+	    echo "$@" >&2
+    else
+	    logger -p daemon.info "$@"
+    fi
+}
+
 # get device name from sysfs
 devname() {
     local dev
@@ -82,7 +92,7 @@ if [ "$cont" = yes ]; then
 		exit 1
 	fi
 elif [ "$restart" = yes ]; then
-	echo 'Re-enabling array checks for all arrays' >&2
+	log 'Re-enabling array checks for all arrays'
 	rm -f /var/lib/mdcheck/Checked_*
 	exit $?
 fi
@@ -110,7 +120,7 @@ cleanup() {
 	fi
 	echo idle > $sys/md/sync_action
 	cat $sys/md/sync_min > $fl
-	logger -p daemon.info pause checking $dev at `cat $fl`
+	log pause checking $dev at `cat $fl`
     done
     rm -f "$tmp"
 }
@@ -141,7 +151,7 @@ do
 	checked="${fl/MD_UUID_/Checked_}"
 	if [[ -f "$fl" ]]; then
 		[[ ! -f "$checked" ]] || {
-		    echo "WARNING: $checked exists, continuing anyway" >&2
+		    log "WARNING: $checked exists, continuing anyway"
 		}
 		start=`cat "$fl"`
 	elif [[ ! -f "$checked" && -z "$cont" ]]; then
@@ -157,7 +167,7 @@ do
 	echo $start > $fl
 	echo $start > $sys/md/sync_min
 	echo check > $sys/md/sync_action
-	logger -p daemon.info mdcheck checking $dev from $start
+	log mdcheck checking $dev from $start
 done
 
 if [ -z "$endtime" ]
@@ -178,7 +188,7 @@ do
 
 		if [ "`cat $sys/md/sync_action`" != 'check' ]
 		then
-			logger -p daemon.info mdcheck finished checking $dev
+			log mdcheck finished checking $dev
 			eval MD_${i}_fl=
 			rm -f "$fl"
 			touch "${fl/MD_UUID_/Checked_}"

--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -31,12 +31,13 @@
 # To support '--continue', arrays are identified by UUID and the 'sync_completed'
 # value is stored  in /var/lib/mdcheck/$UUID
 
-# convert a /dev/md name into /sys/.../md equivalent
-sysname() {
-	set `ls -lLd $1`
-	maj=${5%,}
-	min=$6
-	readlink -f /sys/dev/block/$maj:$min
+# get device name from sysfs
+devname() {
+    local dev
+    [[ -f "$1/uevent" ]] && \
+	    dev=$(. "$1/uevent" && echo -n "$DEVNAME")
+    [[ "$dev" && -b "/dev/$dev" ]] || return 1
+    echo -n "/dev/$dev"
 }
 
 args=$(getopt -o hcd: -l help,continue,duration: -n mdcheck -- "$@")
@@ -100,21 +101,20 @@ mkdir -p /var/lib/mdcheck
 find /var/lib/mdcheck -name "MD_UUID*" -type f -mtime +180 -exec rm {} \;
 
 # Now look at each md device.
-for dev in /dev/md?*
+for sync_act in /sys/block/*/md/sync_action
 do
-	[ -e "$dev" ] || continue
-	sys=`sysname $dev`
-	if [ ! -f "$sys/md/sync_action" ]
-	then # cannot check this array
-		continue
-	fi
-	if [ "`cat $sys/md/sync_action`" != 'idle' ]
+	[ -e "$sync_act" ] || continue
+	if [ "`cat $sync_act`" != 'idle' ]
 	then # This array is busy
 		continue
 	fi
 
+	sys=${sync_act%/md/*}
+	dev=$(devname "$sys") || continue
 	mdadm --detail --export "$dev" | grep '^MD_UUID=' > $tmp || continue
 	source $tmp
+	[[ "$MD_UUID" ]] || continue
+
 	fl="/var/lib/mdcheck/MD_UUID_$MD_UUID"
 	if [ -z "$cont" ]
 	then

--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -21,15 +21,21 @@
 #
 # It supports a 'time budget' such that any incomplete 'check'
 # will be checkpointed when that time has expired.
-# A subsequent invocation can allow the 'check' to continue.
+# A subsequent invocation will allow the 'check' to continue.
 #
 # Options are:
-#   --continue    Don't start new checks, only continue old ones.
+#   --continue    Don't start new checks, only continue previously started ones.
+#   --restart:    Enable restarting the array checks
 #   --duration    This is passed to "date --date=$duration" to find out
 #		  when to finish
 #
-# To support '--continue', arrays are identified by UUID and the 'sync_completed'
-# value is stored  in /var/lib/mdcheck/$UUID
+# Arrays are identified by UUID and the 'sync_completed' value is stored
+# in /var/lib/mdcheck/MD_UUID_$UUID. If this file exists on startup of
+# the script, the check will continue where the previous check left off.
+# After the check completes, /var/lib/mdcheck/Checked_$UUID will be created.
+# Another full check will be started after this file is removed.
+# Use "mdcheck --restart" to remove these markers and re-enable checking
+# all arrays.
 
 # get device name from sysfs
 devname() {
@@ -40,30 +46,46 @@ devname() {
     echo -n "/dev/$dev"
 }
 
-args=$(getopt -o hcd: -l help,continue,duration: -n mdcheck -- "$@")
+args=$(getopt -o hcrd: -l help,continue,restart,duration: -n mdcheck -- "$@")
 rv=$?
 if [ $rv -ne 0 ]; then exit $rv; fi
 
 eval set -- $args
 
 cont=
+restart=
 endtime=
 while [ " $1" != " --" ]
 do
     case $1 in
 	--help )
-		echo >&2 'Usage: mdcheck [--continue] [--duration time-offset]'
+		echo >&2 'Usage: mdcheck [--restart|--continue] [--duration time-offset]'
 		echo >&2 '  time-offset must be understood by "date --date"'
 		exit 0
 		;;
-	--continue ) cont=yes ;;
-	--duration ) shift; dur=$1
+	--continue )
+		cont=yes ;;
+	--restart )
+		restart=yes ;;
+	--duration )
+		shift; dur=$1
 		endtime=$(date --date "$dur" "+%s")
 		;;
     esac
     shift
 done
 shift
+
+if [ "$cont" = yes ]; then
+	if [ "$restart" = yes ]; then
+		echo 'ERROR: --restart and --continue cannot be combined' >&2
+		exit 1
+	fi
+elif [ "$restart" = yes ]; then
+	echo 'Re-enabling array checks for all arrays' >&2
+	rm -f /var/lib/mdcheck/Checked_*
+	exit $?
+fi
 
 # We need a temp file occasionally...
 tmp=/var/lib/mdcheck/.md-check-$$
@@ -116,17 +138,16 @@ do
 	[[ "$MD_UUID" ]] || continue
 
 	fl="/var/lib/mdcheck/MD_UUID_$MD_UUID"
-	if [ -z "$cont" ]
-	then
-		start=0
-		logger -p daemon.info mdcheck start checking $dev
-	elif [ -z "$MD_UUID" -o ! -f "$fl" ]
-	then
-		# Nothing to continue here
-		continue
-	else
+	checked="${fl/MD_UUID_/Checked_}"
+	if [[ -f "$fl" ]]; then
+		[[ ! -f "$checked" ]] || {
+		    echo "WARNING: $checked exists, continuing anyway" >&2
+		}
 		start=`cat "$fl"`
-		logger -p daemon.info mdcheck continue checking $dev from $start
+	elif [[ ! -f "$checked" && -z "$cont" ]]; then
+		start=0
+	else # nothing to do
+		continue
 	fi
 
 	: "$((cnt+=1))"
@@ -136,6 +157,7 @@ do
 	echo $start > $fl
 	echo $start > $sys/md/sync_min
 	echo check > $sys/md/sync_action
+	logger -p daemon.info mdcheck checking $dev from $start
 done
 
 if [ -z "$endtime" ]
@@ -158,7 +180,8 @@ do
 		then
 			logger -p daemon.info mdcheck finished checking $dev
 			eval MD_${i}_fl=
-			rm -f $fl
+			rm -f "$fl"
+			touch "${fl/MD_UUID_/Checked_}"
 			continue;
 		fi
 		read a rest < $sys/md/sync_completed

--- a/systemd/mdcheck_continue.service
+++ b/systemd/mdcheck_continue.service
@@ -7,10 +7,12 @@
 
 [Unit]
 Description=MD array scrubbing - continuation
-ConditionPathExistsGlob=/var/lib/mdcheck/MD_UUID_*
 Documentation=man:mdadm(8)
 
 [Service]
 Type=simple
 Environment="MDADM_CHECK_DURATION=6 hours"
-ExecStart=/usr/share/mdadm/mdcheck --continue --duration ${MDADM_CHECK_DURATION}
+# Note that we're not calling "mdcheck --continue" here.
+# We want previously started checks to be continued, and new ones
+# to be started.
+ExecStart=/usr/share/mdadm/mdcheck --duration ${MDADM_CHECK_DURATION}

--- a/systemd/mdcheck_start.service
+++ b/systemd/mdcheck_start.service
@@ -12,5 +12,4 @@ Documentation=man:mdadm(8)
 
 [Service]
 Type=simple
-Environment="MDADM_CHECK_DURATION=6 hours"
-ExecStart=/usr/share/mdadm/mdcheck --duration ${MDADM_CHECK_DURATION}
+ExecStart=/usr/share/mdadm/mdcheck --restart

--- a/systemd/mdcheck_start.timer
+++ b/systemd/mdcheck_start.timer
@@ -9,7 +9,7 @@
 Description=MD array scrubbing
 
 [Timer]
-OnCalendar=Sun *-*-1..7 1:05:00
+OnCalendar=Sun *-*-1..7 0:45:00
 
 [Install]
 WantedBy= mdmonitor.service


### PR DESCRIPTION
PR on top of #189.

This PR changes the logic of the "mdcheck" tool and the related systemd services `mdcheck_start.service` and `mdcheck_continue.service`.

The current behavior is like this:

* `mdcheck` without arguments starts a RAID check on all arrays on the system, starting at position 0. This is started from `mdcheck_start.service`, started by a systemd timer once a month.
* `mdcheck --continue` looks for files `/var/lib/mdcheck/MD_UUID_$UUID`, reads the start position from them, and starts a check from that position on the array with the respective UUID. This is started from a systemd timer every night. 

In either case, `mdcheck` won't do anything if the kernel is already running a `sync_action` on a given array. The check runs for a given period of time (default 6h) and saves the last position in the `MD_UUID` file, to be taken up when `mdcheck --continue` is called next time. When the entire array has been checked, the `MD_UUID_` file is deleted. When all checks are finished, `mdcheck_continue.timer` is stopped, to be restarted when `mdcheck_start.timer` expires next time.

Before the recent commit 8aa4ea9 ("systemd: start mdcheck_continue.timer before mdcheck_start.timer"), this could lead to a race condition when the check for a given array didn't complete throughout the month. `mdcheck_start.service` would start and reset the check position to 0 before `mdcheck_continue.service` could pick up at the last saved position. 8aa4ea9 works around this by starting mdcheck_continue.service a few minutes before mdcheck_start.timer.

Yet the general problem still exists: both services trigger checks on the kernel's part which they can only passively monitor. So if a user plays with the timer settings (which he is in his rights to do), another similar race might happen.

This patch set changes the behavior as follows:

Only `mdcheck_continue.service` actually starts and stops kernel-based sync actions. This service will continue at the saved start position if an `MD_UUID*` file exists, or start a new check at position 0 otherwise. Starting at 0 can be inhibited by creating a file `/var/lib/mdcheck/Checked_$UUID`. These files will be created by `mdcheck` when it finishes checking a given array. Thus future invocations of `mdcheck_continue.service` will not restart the check on this array.

`mdcheck_start.service` runs `mdcheck --restart`, which simply removes all `Checked_*` markers from `/var/lib/mdcheck`, so that the next invocation of `mdcheck_continue.service` will start new checks on all arrays which don't have already running checks.

The general behavior of the systemd timers and services is like before, but the mentioned race condition is avoided, even if the user modifies the timer settings arbitrarily.

This set slightly changes the behavior of the `mdcheck` script. Without `--continue`, it will still start checks on all array, but unlike before it will skip arrays for with a `Checked_` marker exists. To avoid that, run `mdcheck --restart` before `mdcheck`.

More details in the commit description of the patch "mdcheck: simplify start / continue logic and add "--restart" logic".
