### PR TITLE
Fix --monitor --scan with relative ARRAY devnames

### DIFF
--- a/mdmonitor.c
+++ b/mdmonitor.c
@@ -254,12 +254,14 @@ int Monitor(struct mddev_dev *devlist,
 				continue;
 			if (is_devname_ignore(mdlist->devname) == true)
 				continue;
-			if (!is_mddev(mdlist->devname))
-				continue;
 
 			st = xcalloc(1, sizeof *st);
 			snprintf(st->devname, MD_NAME_MAX + sizeof(DEV_MD_DIR), DEV_MD_DIR "%s",
 				 basename(mdlist->devname));
+			if (!is_mddev(st->devname)) {
+				free(st);
+				continue;
+			}
 			st->next = statelist;
 			st->devnm[0] = 0;
 			st->percent = RESYNC_UNKNOWN;


### PR DESCRIPTION
Since commit e702f392959d ("Mdmonitor: Fix segfault"), when configuration files used non-absolute ARRAY device names, commands like `mdadm --monitor --scan` failed with `mdadm: error opening devname: No such file or directory` unless run from the `/dev/md` directory.