### PR TITLE
Fix regression: Re-enable mdadm --monitor ... for /dev/mdX

### DIFF
--- a/mdmonitor.c
+++ b/mdmonitor.c
@@ -258,8 +258,13 @@ int Monitor(struct mddev_dev *devlist,
 				continue;
 
 			st = xcalloc(1, sizeof *st);
-			snprintf(st->devname, MD_NAME_MAX + sizeof(DEV_MD_DIR), DEV_MD_DIR "%s",
-				 basename(mdlist->devname));
+			if ( '/' == *mdlist->devname ) {
+				snprintf(st->devname, MD_NAME_MAX + sizeof(DEV_MD_DIR), "%s",
+					 mdlist->devname);
+			} else {
+				snprintf(st->devname, MD_NAME_MAX + sizeof(DEV_MD_DIR), DEV_MD_DIR "%s",
+					 basename(mdlist->devname));
+			}
 			st->next = statelist;
 			st->devnm[0] = 0;
 			st->percent = RESYNC_UNKNOWN;


### PR DESCRIPTION
After commit
<https://github.com/md-raid-utilities/mdadm/commit/84d969be8f6d8a345b75f558fad26e4f62a558f6>
it is no longer possible to monitor md devices with device files like
`/dev/md0`, `/dev/md1` ... which have no corresponding symbolic link in
directory `/dev/md/`

The proposed pull request fixes this beviour.


# Steps to reproduce the error:


Create block devices for testing:

```
# dd if=/dev/zero of=/tmp/d0.bin bs=1M count=16
# dd if=/dev/zero of=/tmp/d1.bin bs=1M count=16
```

```
# losetup
# losetup -f /tmp/d0.bin
# losetup -f /tmp/d1.bin
# losetup
NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE   DIO LOG-SEC
/dev/loop1         0      0         0  0 /tmp/d1.bin   0     512
/dev/loop0         0      0         0  0 /tmp/d0.bin   0     512
```

Create RAID-1 array `/dev/md0`:

```
# mdadm --create /dev/md0 --level=1 --raid-devices=2 /dev/loop0 /dev/loop1
mdadm: Note: this array has metadata at the start and
    may not be suitable as a boot device.  If you plan to
    store '/boot' on this device please ensure that
    your boot-loader understands md/v1.x metadata, or use
    --metadata=0.90
Continue creating array? y
mdadm: Defaulting to version 1.2 metadata
mdadm: array /dev/md0 started.
```


Some checks:

```
# ls -al /dev/md0
brw-rw---- 1 root disk 9, 0 Sep  6 10:28 /dev/md0
# ls -al /dev/md
ls: cannot access '/dev/md': No such file or directory

# dmesg
...
[54702.435014] loop0: detected capacity change from 0 to 32768
[54706.595318] loop1: detected capacity change from 0 to 32768
[54906.608688] md/raid1:md0: not clean -- starting background reconstruction
[54906.608694] md/raid1:md0: active with 2 out of 2 mirrors
[54906.608710] md0: detected capacity change from 0 to 30720
[54906.608992] md: resync of RAID array md0
[54906.626671] md: md0: resync done.

# cat /proc/mdstat
Personalities : [raid1]
md0 : active raid1 loop1[1] loop0[0]
      15360 blocks super 1.2 [2/2] [UU]

unused devices: <none>
```

Create `mdadm.conf`:

```
# mdadm --detail --scan > /tmp/mdadm.conf
# cat /tmp/mdadm.conf
ARRAY /dev/md0 metadata=1.2 UUID=c0280f55:9c32e4ff:34f85ea3:08d1331b
```


We use this script (`report`) located in directory $dir for
`mdadm --monitor`:


```
#!/bin/bash -
umask 022
LANG='C'
PATH='/sbin:/bin:/usr/sbin:/usr/bin'
export LANG PATH


[[ $# -lt 2 ]] && exit 0

problem="$1"
shift
array="$1"
shift
args="$*"

echo "MD REPORT: ${problem} with ${array}: ${args}"


# EOF
```


Now we call

```
# mdadm  --monitor  -c /tmp/mdadm.conf --scan -1 -p ${dir}/report
```

And get this output:

```
mdadm: DeviceDisappeared event detected on md device /dev/md/md0
MD REPORT: DeviceDisappeared with /dev/md/md0:
mdadm: NewArray event detected on md device /dev/md0
MD REPORT: NewArray with /dev/md0:
```

Only the output of the `report`-script:

```
# mdadm  --monitor  -c /tmp/mdadm.conf --scan -1 -p ${dir}/report 2>/dev/null
MD REPORT: DeviceDisappeared with /dev/md/md0:
MD REPORT: NewArray with /dev/md0:
```

If --- as typically used --- the `report` script would send an e-mail
message and the `mdadm --monitor ...` would be called via a cron job
we would get perodically the above warning messages.


With the proposed fix:


```
# ${dir}/mdadm-FIX  --monitor  -c /tmp/mdadm.conf --scan -1 -p ${dir}/report
```


OS-Version used for testing:

```
# cat /etc/fedora-release
Fedora release 41 (Forty One)
# uname -a
Linux linuxws 6.14.11-200.fc41.x86_64 #1 SMP PREEMPT_DYNAMIC Tue Jun 10 16:33:19 UTC 2025 x86_64 GNU/Linux
```

