### PR TITLE
udev: Fix memleak

### DIFF
--- a/udev.c
+++ b/udev.c
@@ -147,9 +147,16 @@ enum udev_status udev_wait_for_events(int seconds)
 	tv.tv_sec = seconds;
 	tv.tv_usec = 0;
 
-	if (select(fd + 1, &readfds, NULL, NULL, &tv) > 0 && FD_ISSET(fd, &readfds))
-		if (udev_monitor_receive_device(udev_monitor))
+	if (select(fd + 1, &readfds, NULL, NULL, &tv) > 0 && FD_ISSET(fd, &readfds)) {
+		struct udev_device *dev = udev_monitor_receive_device(udev_monitor);
+
+		if (dev) {
+			udev_device_unref(dev);
 			return UDEV_STATUS_SUCCESS; /* event detected */
+		} else {
+			return UDEV_STATUS_ERROR;
+		}
+	}
 	return UDEV_STATUS_TIMEOUT;
 }
 #endif


### PR DESCRIPTION
According to manual:
On success, udev_monitor_receive_device() returns a pointer to a newly referenced device that was received via the monitor. The caller is responsible to drop this reference when done.

Fixes:#195 