### PR TITLE
mdadm: add support for new lockless bitmap

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -1029,6 +1029,11 @@ static int start_array(int mdfd,
 	int i;
 	unsigned int req_cnt;
 
+	if (st->ss->get_bitmap_type &&
+	    st->ss->get_bitmap_type(st) == BITMAP_MAJOR_LOCKLESS &&
+	    sysfs_set_str(content, NULL, "bitmap_type", "llbitmap"))
+		return 1;
+
 	if (content->journal_device_required && (content->journal_clean == 0)) {
 		if (!c->force) {
 			pr_err("Not safe to assemble with missing or stale journal device, consider --force.\n");

--- a/Grow.c
+++ b/Grow.c
@@ -377,7 +377,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 		free(mdi);
 	}
 
-	if (s->btype == BitmapInternal || s->btype == BitmapCluster) {
+	if (s->btype == BitmapInternal || s->btype == BitmapCluster ||
+	    s->btype == BitmapLockless) {
 		int rv;
 		int d;
 		int offset_setable = 0;
@@ -419,7 +420,7 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 				rv = st->ss->add_internal_bitmap(
 					st, &s->bitmap_chunk, c->delay,
 					s->write_behind, bitmapsize,
-					offset_setable, major);
+					offset_setable, major, 0);
 				if (!rv) {
 					st->ss->write_bitmap(st, fd2,
 							     NodeNumUpdate);

--- a/bitmap.h
+++ b/bitmap.h
@@ -14,12 +14,17 @@
 #define BITMAP_MAJOR_LO 3
 #define BITMAP_MAJOR_HI 4
 #define	BITMAP_MAJOR_CLUSTERED 5
+#define BITMAP_MAJOR_LOCKLESS 6
 #define BITMAP_MAGIC 0x6d746962
 
 /* use these for bitmap->flags and bitmap->sb->state bit-fields */
 enum bitmap_state {
-	BITMAP_ACTIVE = 0x001, /* the bitmap is in use */
-	BITMAP_STALE  = 0x002  /* the bitmap file is out of date or had -EIO */
+	BITMAP_STALE		= 1,  /* the bitmap file is out of date or had -EIO */
+	BITMAP_WRITE_ERROR	= 2, /* A write error has occurred */
+	BITMAP_FIRST_USE	= 3,
+	BITMAP_CLEAN		= 4,
+	BITMAP_DAEMON_BUSY	= 5,
+	BITMAP_HOSTENDIAN	= 15,
 };
 
 /* the superblock at the front of the bitmap file -- little endian */

--- a/mdadm.c
+++ b/mdadm.c
@@ -56,6 +56,12 @@ static mdadm_status_t set_bitmap_value(struct shape *s, struct context *c, char 
 		return MDADM_STATUS_SUCCESS;
 	}
 
+	if (strcmp(val, "lockless") == 0) {
+		s->btype = BitmapLockless;
+		pr_info("Experimental lockless bitmap, use at your own disk!\n");
+		return MDADM_STATUS_SUCCESS;
+	}
+
 	if (strcmp(val, "clustered") == 0) {
 		s->btype = BitmapCluster;
 		/* Set the default number of cluster nodes
@@ -1245,7 +1251,8 @@ int main(int argc, char *argv[])
 			pr_err("--bitmap is required for consistency policy: %s\n",
 			       map_num_s(consistency_policies, s.consistency_policy));
 			exit(2);
-		} else if ((s.btype == BitmapInternal || s.btype == BitmapCluster) &&
+		} else if ((s.btype == BitmapInternal || s.btype == BitmapCluster ||
+			    s.btype == BitmapLockless) &&
 			   s.consistency_policy != CONSISTENCY_POLICY_BITMAP &&
 			   s.consistency_policy != CONSISTENCY_POLICY_JOURNAL) {
 			pr_err("--bitmap is not compatible with consistency policy: %s\n",

--- a/mdadm.h
+++ b/mdadm.h
@@ -558,6 +558,7 @@ enum bitmap_type {
 	BitmapNone,
 	BitmapInternal,
 	BitmapCluster,
+	BitmapLockless,
 	BitmapUnknown,
 };
 
@@ -1151,7 +1152,9 @@ extern struct superswitch {
 	 */
 	int (*add_internal_bitmap)(struct supertype *st, int *chunkp,
 				   int delay, int write_behind,
-				   unsigned long long size, int may_change, int major);
+				   unsigned long long size, int may_change,
+				   int major, bool assume_clean);
+	int (*get_bitmap_type)(struct supertype *st);
 	/* Perform additional setup required to activate a bitmap.
 	 */
 	int (*set_bitmap)(struct supertype *st, struct mdinfo *info);

--- a/super-intel.c
+++ b/super-intel.c
@@ -13011,7 +13011,7 @@ static int validate_internal_bitmap_imsm(struct supertype *st)
 static int add_internal_bitmap_imsm(struct supertype *st, int *chunkp,
 				    int delay, int write_behind,
 				    unsigned long long size, int may_change,
-				    int amajor)
+				    int amajor, bool assume_clean)
 {
 	struct intel_super *super = st->sb;
 	int vol_idx = super->current_vol;

--- a/super0.c
+++ b/super0.c
@@ -1185,7 +1185,7 @@ static __u64 avail_size0(struct supertype *st, __u64 devsize,
 static int add_internal_bitmap0(struct supertype *st, int *chunkp,
 				int delay, int write_behind,
 				unsigned long long size, int may_change,
-				int major)
+				int major, bool assume_clean)
 {
 	/*
 	 * The bitmap comes immediately after the superblock and must be 60K in size


### PR DESCRIPTION
A new major number 6 is used for the new bitmap.

Noted that for the kernel that doesn't support lockless bitmap, create such array will fail:

md0: invalid bitmap file superblock: unrecognized superblock version.