### PR TITLE
mdadm: Create array with sync del gendisk mode

### DIFF
--- a/mdadm.h
+++ b/mdadm.h
@@ -141,6 +141,8 @@ struct dlm_lksb {
 #define MDMON_DIR "/run/mdadm"
 #endif /* MDMON_DIR */
 
+#define MD_MOD_ASYNC_DEL_GENDISK "legacy_async_del_gendisk"
+
 /* FAILED_SLOTS is where to save files storing recent removal of array
  * member in order to allow future reuse of disk inserted in the same
  * slot for array recovery
@@ -855,6 +857,8 @@ extern int restore_stripes(int *dest, unsigned long long *offsets,
 			   unsigned long long start, unsigned long long length,
 			   char *src_buf);
 extern bool sysfs_is_libata_allow_tpm_enabled(const int verbose);
+extern bool init_md_mod_param(char *buffer, int bsize);
+extern void restore_md_mod_param(char *buffer);
 
 #ifndef Sendmail
 #define Sendmail "/usr/lib/sendmail -t"
@@ -1794,6 +1798,8 @@ extern void set_dlm_hooks(void);
 extern void sleep_for(unsigned int sec, long nsec, bool wake_after_interrupt);
 extern bool is_directory(const char *path);
 extern bool is_file(const char *path);
+extern bool get_md_mod_parameter(const char *name, char *buffer, int bsize);
+extern bool set_md_mod_parameter(const char *name, const char *value);
 extern int s_gethostname(char *buf, int buf_len);
 
 #define _ROUND_UP(val, base)	(((val) + (base) - 1) & ~(base - 1))

--- a/sysfs.c
+++ b/sysfs.c
@@ -1269,3 +1269,33 @@ bool sysfs_is_libata_allow_tpm_enabled(const int verbose)
 		return true;
 	return false;
 }
+
+bool init_md_mod_param(char *buffer, int bsize)
+{
+	bool ret = true;
+
+	/*
+	 * Init md module parameter legacy_async_del_gendisk to N
+	 */
+	if (get_linux_version() >= 6018000) {
+		ret = get_md_mod_parameter(MD_MOD_ASYNC_DEL_GENDISK, buffer, bsize);
+		if (!ret)
+			return ret;
+
+		ret = set_md_mod_parameter(MD_MOD_ASYNC_DEL_GENDISK, "N");
+	}
+
+	return ret;
+}
+
+void restore_md_mod_param(char *buffer)
+{
+	bool ret = true;
+
+	if (get_linux_version() >= 6018000) {
+		ret = set_md_mod_parameter(MD_MOD_ASYNC_DEL_GENDISK, buffer);
+		if (!ret)
+			pr_err("restore %s to %s fail\n", buffer,
+					MD_MOD_ASYNC_DEL_GENDISK);
+	}
+}


### PR DESCRIPTION
9e59d609763f70a992a8f3808dabcce60f14eb5c (md: call del_gendisk in control path) calls del_gendisk in sync way. After this patch, device node (/dev/md0 .e.g) will disappear after mdadm --stop command. It resolves the problem raid can be created again because raid can be created when opening device node. Then regression tests will be interrupted.

But it causes an error when assembling array which has been fixed by #182. But upstream people think it's not right to do so. Because people will encounter error who using old mdadm version. So in kernel space, 25db5f284fb8f30222146ca15b3ab8265789da38 (md: add legacy_async_del_gendisk mod) is used to fix this problem. The default is async mode.

We need to set sync mode when creating array to use sync mode to del gendisk.