### PR TITLE
mdadm/Assemble: alloc superblock in Assemble

### DIFF
--- a/mdadm.c
+++ b/mdadm.c
@@ -107,6 +107,7 @@ int main(int argc, char *argv[])
 	int grow_continue = 0;
 	struct context c = {
 		.require_homehost = 1,
+		.metadata = NULL,
 	};
 	struct shape s = {
 		.journaldisks	= 0,
@@ -445,6 +446,7 @@ int main(int argc, char *argv[])
 				pr_err("unrecognised metadata identifier: %s\n", optarg);
 				exit(2);
 			}
+			c.metadata = optarg;
 			continue;
 
 		case O(MANAGE,'W'):
@@ -1424,10 +1426,10 @@ int main(int argc, char *argv[])
 				if (mdfd >= 0)
 					close(mdfd);
 			} else {
-				rv |= Assemble(ss, ident.devname, array_ident, NULL, &c);
+				rv |= Assemble(ident.devname, array_ident, NULL, &c);
 			}
 		} else if (!c.scan)
-			rv = Assemble(ss, ident.devname, &ident, devlist->next, &c);
+			rv = Assemble(ident.devname, &ident, devlist->next, &c);
 		else if (devs_found > 0) {
 			if (c.update && devs_found > 1) {
 				pr_err("can only update a single array at a time\n");
@@ -1445,7 +1447,7 @@ int main(int argc, char *argv[])
 					rv |= 1;
 					continue;
 				}
-				rv |= Assemble(ss, dv->devname, array_ident, NULL, &c);
+				rv |= Assemble(dv->devname, array_ident, NULL, &c);
 			}
 		} else {
 			if (c.update) {
@@ -1737,7 +1739,7 @@ static int scan_assemble(struct supertype *ss,
 			if (a->devname && is_devname_ignore(a->devname) == true)
 				continue;
 
-			r = Assemble(ss, a->devname,
+			r = Assemble(a->devname,
 				     a, NULL, c);
 			if (r == 0) {
 				a->assembled = 1;
@@ -1760,7 +1762,7 @@ static int scan_assemble(struct supertype *ss,
 			struct mddev_dev *devlist = conf_get_devs();
 			acnt = 0;
 			do {
-				rv2 = Assemble(ss, NULL,
+				rv2 = Assemble(NULL,
 					       ident,
 					       devlist, c);
 				if (rv2 == 0) {

--- a/mdadm.h
+++ b/mdadm.h
@@ -636,6 +636,7 @@ struct context {
 	char	*action;
 	int	nodes;
 	char	*homecluster;
+	char	*metadata;
 };
 
 struct shape {
@@ -1513,10 +1514,8 @@ extern int restore_backup(struct supertype *st,
 			  int verbose);
 extern int Grow_continue_command(char *devname, int fd, struct context *c);
 
-extern int Assemble(struct supertype *st, char *mddev,
-		    struct mddev_ident *ident,
-		    struct mddev_dev *devlist,
-		    struct context *c);
+extern int Assemble(char *mddev, struct mddev_ident *ident,
+			struct mddev_dev *devlist, struct context *c);
 
 extern int Build(struct mddev_ident *ident, struct mddev_dev *devlist, struct shape *s,
 		 struct context *c);


### PR DESCRIPTION
load_devices may replaces superblock pointer if it finds the better one from member disks. In this way, it releases the memory which passes to Assemble by argument pointer st. The function main doesn't know this. So it may dereference a memory region which has been released after existing from Assemble.

This can be reproduced by:
mdadm -CR /dev/md0 -l1 -n2 /dev/loop0 /dev/loop1 --assume-clean mdadm -Ss
mdadm -A -e 1.2 /dev/md0 /dev/loop0 /dev/loop1

This patch uses a double pointer as the argument for Assemble. So it can reset the pointer after load_devices.