### PR TITLE
mdadm: add support for new lockless bitmap

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -1828,6 +1828,11 @@ try_again:
 		close(fd);
 	}
 
+	if (st->ss->get_bitmap_type &&
+	    st->ss->get_bitmap_type(st) == BITMAP_MAJOR_LOCKLESS &&
+	    sysfs_set_str(content, NULL, "bitmap_type", "llbitmap"))
+		goto out;
+
 	/* If we are in the middle of a reshape we may need to restore saved data
 	 * that was moved aside due to the reshape overwriting live data
 	 * The code of doing this lives in Grow.c

--- a/Grow.c
+++ b/Grow.c
@@ -377,7 +377,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 		free(mdi);
 	}
 
-	if (s->btype == BitmapInternal || s->btype == BitmapCluster) {
+	if (s->btype == BitmapInternal || s->btype == BitmapCluster ||
+	    s->btype == BitmapLockless) {
 		int rv;
 		int d;
 		int offset_setable = 0;
@@ -419,7 +420,7 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 				rv = st->ss->add_internal_bitmap(
 					st, &s->bitmap_chunk, c->delay,
 					s->write_behind, bitmapsize,
-					offset_setable, major);
+					offset_setable, major, 0);
 				if (!rv) {
 					st->ss->write_bitmap(st, fd2,
 							     NodeNumUpdate);

--- a/bitmap.h
+++ b/bitmap.h
@@ -14,12 +14,17 @@
 #define BITMAP_MAJOR_LO 3
 #define BITMAP_MAJOR_HI 4
 #define	BITMAP_MAJOR_CLUSTERED 5
+#define BITMAP_MAJOR_LOCKLESS 6
 #define BITMAP_MAGIC 0x6d746962
 
 /* use these for bitmap->flags and bitmap->sb->state bit-fields */
 enum bitmap_state {
-	BITMAP_ACTIVE = 0x001, /* the bitmap is in use */
-	BITMAP_STALE  = 0x002  /* the bitmap file is out of date or had -EIO */
+	BITMAP_STALE		= 1,  /* the bitmap file is out of date or had -EIO */
+	BITMAP_WRITE_ERROR	= 2, /* A write error has occurred */
+	BITMAP_FIRST_USE	= 3,
+	BITMAP_CLEAN		= 4,
+	BITMAP_DAEMON_BUSY	= 5,
+	BITMAP_HOSTENDIAN	= 15,
 };
 
 /* the superblock at the front of the bitmap file -- little endian */

--- a/mdadm.c
+++ b/mdadm.c
@@ -57,6 +57,12 @@ static mdadm_status_t set_bitmap_value(struct shape *s, struct context *c, char 
 		return MDADM_STATUS_SUCCESS;
 	}
 
+	if (strcmp(val, "lockless") == 0) {
+		s->btype = BitmapLockless;
+		pr_info("Experimental lockless bitmap, use at your own disk!\n");
+		return MDADM_STATUS_SUCCESS;
+	}
+
 	if (strcmp(val, "clustered") == 0) {
 		s->btype = BitmapCluster;
 		/* Set the default number of cluster nodes
@@ -1292,7 +1298,8 @@ int main(int argc, char *argv[])
 			pr_err("--bitmap is required for consistency policy: %s\n",
 			       map_num_s(consistency_policies, s.consistency_policy));
 			exit(2);
-		} else if ((s.btype == BitmapInternal || s.btype == BitmapCluster) &&
+		} else if ((s.btype == BitmapInternal || s.btype == BitmapCluster ||
+			    s.btype == BitmapLockless) &&
 			   s.consistency_policy != CONSISTENCY_POLICY_BITMAP &&
 			   s.consistency_policy != CONSISTENCY_POLICY_JOURNAL) {
 			pr_err("--bitmap is not compatible with consistency policy: %s\n",

--- a/mdadm.h
+++ b/mdadm.h
@@ -561,6 +561,7 @@ enum bitmap_type {
 	BitmapNone,
 	BitmapInternal,
 	BitmapCluster,
+	BitmapLockless,
 	BitmapUnknown,
 };
 
@@ -1157,7 +1158,9 @@ extern struct superswitch {
 	 */
 	int (*add_internal_bitmap)(struct supertype *st, int *chunkp,
 				   int delay, int write_behind,
-				   unsigned long long size, int may_change, int major);
+				   unsigned long long size, int may_change,
+				   int major, bool assume_clean);
+	int (*get_bitmap_type)(struct supertype *st);
 	/* Perform additional setup required to activate a bitmap.
 	 */
 	int (*set_bitmap)(struct supertype *st, struct mdinfo *info);

--- a/super-intel.c
+++ b/super-intel.c
@@ -13011,7 +13011,7 @@ static int validate_internal_bitmap_imsm(struct supertype *st)
 static int add_internal_bitmap_imsm(struct supertype *st, int *chunkp,
 				    int delay, int write_behind,
 				    unsigned long long size, int may_change,
-				    int amajor)
+				    int amajor, bool assume_clean)
 {
 	struct intel_super *super = st->sb;
 	int vol_idx = super->current_vol;

--- a/super0.c
+++ b/super0.c
@@ -1185,7 +1185,7 @@ static __u64 avail_size0(struct supertype *st, __u64 devsize,
 static int add_internal_bitmap0(struct supertype *st, int *chunkp,
 				int delay, int write_behind,
 				unsigned long long size, int may_change,
-				int major)
+				int major, bool assume_clean)
 {
 	/*
 	 * The bitmap comes immediately after the superblock and must be 60K in size

--- a/super1.c
+++ b/super1.c
@@ -2375,11 +2375,19 @@ static __u64 avail_size1(struct supertype *st, __u64 devsize,
 	return 0;
 }
 
+static int get_bitmap_type1(struct supertype *st)
+{
+	struct mdp_superblock_1 *sb = st->sb;
+	bitmap_super_t *bms = (bitmap_super_t *)(((char *)sb) + MAX_SB_SIZE);
+
+	return __le32_to_cpu(bms->version);
+}
+
 static int
 add_internal_bitmap1(struct supertype *st,
 		     int *chunkp, int delay, int write_behind,
 		     unsigned long long size,
-		     int may_change, int major)
+		     int may_change, int major, bool assume_clean)
 {
 	/*
 	 * If not may_change, then this is a 'Grow' without sysfs support for
@@ -2409,6 +2417,14 @@ add_internal_bitmap1(struct supertype *st,
 		 * would be non-zero
 		 */
 		creating = 1;
+
+	if (major == BITMAP_MAJOR_LOCKLESS) {
+		if (!creating || st->minor_version != 2) {
+			pr_err("lockless bitmap is only supported with creating the array with 1.2 metadata\n");
+			return -EINVAL;
+		}
+	}
+
 	switch(st->minor_version) {
 	case 0:
 		/*
@@ -2477,9 +2493,16 @@ add_internal_bitmap1(struct supertype *st,
 	}
 
 	room -= bbl_size;
-	if (chunk == UnSet && room > 128*2)
+	if (major == BITMAP_MAJOR_LOCKLESS) {
+		if (chunk != UnSet) {
+			pr_err("lockless bitmap doesn't support chunksize\n");
+			return -EINVAL;
+		}
+		room = 128*2;
+	} else if (chunk == UnSet && room > 128*2) {
 		/* Limit to 128K of bitmap when chunk size not requested */
 		room = 128*2;
+	}
 
 	if (room <= 1)
 		/* No room for a bitmap */
@@ -2538,6 +2561,13 @@ add_internal_bitmap1(struct supertype *st,
 		bms->cluster_name[len - 1] = '\0';
 	}
 
+	/* kernel will initialize bitmap */
+	if (major == BITMAP_MAJOR_LOCKLESS) {
+		bms->state = __cpu_to_le32(1 << BITMAP_FIRST_USE);
+		if (assume_clean)
+			bms->state |= __cpu_to_le32(1 << BITMAP_CLEAN);
+		bms->sectors_reserved = __le32_to_cpu(room);
+	}
 	*chunkp = chunk;
 	return 0;
 }
@@ -2913,6 +2943,7 @@ struct superswitch super1 = {
 	.avail_size = avail_size1,
 	.add_internal_bitmap = add_internal_bitmap1,
 	.locate_bitmap = locate_bitmap1,
+	.get_bitmap_type = get_bitmap_type1,
 	.write_bitmap = write_bitmap1,
 	.free_super = free_super1,
 #if __BYTE_ORDER == BIG_ENDIAN


### PR DESCRIPTION
A new major number 6 is used for the new bitmap.

Noted that for the kernel that doesn't support lockless bitmap, create such array will fail:

md0: invalid bitmap file superblock: unrecognized superblock version.