### PR TITLE
github: disable self-runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,5 @@
 name: tests
 on:
-  schedule:
-    - cron: "0 0 * * *"
   pull_request:
     paths:
       - '*.c'
@@ -13,7 +11,7 @@ on:
       - '.github/tools/*'
 jobs:
   upstream_tests:
-     if: ${{ github.repository == 'md-raid-utilities/mdadm' }}
+     if: ${{ github.repository == 'disabled' }} # Intel hosted runners are down
      runs-on: self-hosted
      timeout-minutes: 150
      name: upstream tests


### PR DESCRIPTION
Runners are not avaialable, disable them. There are actions to get new runners so keep a code for a while.