### PR TITLE
mdadm --create supports --logical-block-size option

### DIFF
--- a/Create.c
+++ b/Create.c
@@ -1281,6 +1281,14 @@ int Create(struct supertype *st, struct mddev_ident *ident, int subdevs,
 				goto abort;
 			}
 		} else {
+			if (s->logical_block_size &&
+				sysfs_set_num(&info, NULL, "logical_block_size",
+							  s->logical_block_size)) {
+				pr_err("Failed to set logical_block_size %u\n",
+						s->logical_block_size);
+				goto abort;
+			}
+
 			/* param is not actually used */
 			mdu_param_t param;
 			if (ioctl(mdfd, RUN_ARRAY, &param)) {

--- a/ReadMe.c
+++ b/ReadMe.c
@@ -149,6 +149,7 @@ struct option long_options[] = {
 	{"home-cluster", 1, 0, ClusterName},
 	{"write-journal", 1, 0, WriteJournal},
 	{"consistency-policy", 1, 0, 'k'},
+	{"logical-block-size", 1, 0, LogicalBlockSize},
 
 	/* For assemble */
 	{"uuid", 1, 0, 'u'},
@@ -331,6 +332,7 @@ char Help_create[] =
 "  --consistency-policy= : Specify the policy that determines how the array\n"
 "                     -k : maintains consistency in case of unexpected shutdown.\n"
 "  --write-zeroes        : Write zeroes to the disks before creating. This will bypass initial sync.\n"
+"  --logical-block-size= : Set the logical block size (in Byte) for the RAID.\n"
 "\n"
 ;
 

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -989,6 +989,21 @@ Can be used with \-\-grow to change the consistency policy of an active array
 in some cases. See CONSISTENCY POLICY CHANGES below.
 .RE
 
+.TP
+.BR \-\-logical\-block\-size=
+The option can only be used in Create mode and metadata version is 1.x. If during
+creation, the member disks have mixed LBS values (512 and 4K), the array will
+default to using 4K as its LBS. However, if the 4K disk is removed and the system
+is rebooted, the array's LBS will fall back to 512. If the array's LBS is 512,
+then a disk with a 4K LBS cannot be added to the array.
+
+In general, choosing a large LBS for the array is beneficial, but it can
+introduce write-amplification. The larger the array's LBS, the larger the write
+size to each member disk. Therefore, users should evaluate their actual workload
+and choose an appropriate LBS accordingly.
+
+The option should be set by the user based on their own usage scenario, choosing
+an LBS value that best matches their needs.
 
 .SH For assemble:
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -496,6 +496,7 @@ enum special_options {
 	ClusterConfirm,
 	WriteJournal,
 	ConsistencyPolicy,
+	LogicalBlockSize,
 };
 
 enum update_opt {
@@ -657,6 +658,7 @@ struct shape {
 	unsigned long long data_offset;
 	int	consistency_policy;
 	change_dir_t direction;
+	unsigned int logical_block_size;
 };
 
 /* List of device names - wildcards expanded */


### PR DESCRIPTION
    The kernel block branch has started supporting the
    configuration of logical block size after mergeing commit
    62ed1b582246 (md:allow configuring logical block size),
    therefore a new parameter should be added to allow specifying
    the logical block size when creating a RAID device.

    Links: https://git.kernel.org/pub/scm/linux/kernel/git/axboe/linux.git/commit/?h=for-6.19/block&id=62ed1b582246
 