### PR TITLE
mdcheck: work around bash 5.3 bug

### DIFF
--- a/misc/mdcheck
+++ b/misc/mdcheck
@@ -58,8 +58,11 @@ log() {
 devname() {
     local dev
     [[ -f "$1/uevent" ]] && \
-	    dev=$(. "$1/uevent" && echo -n "$DEVNAME")
-    [[ "$dev" && -b "/dev/$dev" ]] || return 1
+	    dev=$(eval "$(cat "$1/uevent")"; echo -n "$DEVNAME")
+    [[ "$dev" && -b "/dev/$dev" ]] || {
+	log "failed to read DEVNAME from $1"
+	return 1
+    }
     echo -n "/dev/$dev"
 }
 


### PR DESCRIPTION
The idiom `(. "$1/uevent" && echo -n "$DEVNAME")` is generally correct, and works with bash <= 5.2 and all other shells I've tried.

But it fails with bash 5.3. Using a combination of "eval" and "cat" works, and should be portable, too.

Bash bug report: https://savannah.gnu.org/bugs/index.php?67723
