### PR TITLE
super1.c: fix crash with homehost=none

### DIFF
--- a/super1.c
+++ b/super1.c
@@ -1102,7 +1102,8 @@ static int update_super1(struct supertype *st, struct mdinfo *info,
 			snprintf(info->name, sizeof(info->name), "%d", info->array.md_minor);
 		memset(sb->set_name, 0, sizeof(sb->set_name));
 
-		namelen = strnlen(homehost, MD_NAME_MAX) + 1 + strnlen(info->name, MD_NAME_MAX);
+		namelen = (homehost ? strnlen(homehost, MD_NAME_MAX) : 0)
+			+ 1 + strnlen(info->name, MD_NAME_MAX);
 		if (homehost &&
 		    strchr(info->name, ':') == NULL &&
 		    namelen < MD_NAME_MAX) {


### PR DESCRIPTION
Problem:
mdadm --assemble --update=name --homehost="<none>" --name="myraid" "/dev/md/myraid" /dev/vdb1 /dev/vdc1
> Segmentation fault (core dumped)

homehost == NULL ist tested all over the place in mdadm, but this place has apparently been overlooked.

Suggested-by: Lidong Zhong <lidong.zhong@suse.com>