### PR TITLE
variable "sigterm" must be volatile sig_atomic_t

### DIFF
--- a/Grow.c
+++ b/Grow.c
@@ -2984,7 +2984,7 @@ static int impose_level(int fd, int level, char *devname, int verbose)
 	return 0;
 }
 
-int sigterm = 0;
+volatile sig_atomic_t sigterm = 0;
 static void catch_term(int sig)
 {
 	sigterm = 1;

--- a/mdmon.c
+++ b/mdmon.c
@@ -74,7 +74,7 @@ struct active_array *pending_discard;
 
 int mon_tid, mgr_tid;
 
-int sigterm;
+volatile sig_atomic_t sigterm;
 
 #ifdef USE_PTHREADS
 static void *run_child(void *v)

--- a/mdmon.h
+++ b/mdmon.h
@@ -81,7 +81,7 @@ extern struct md_generic_cmd *active_cmd;
 void remove_pidfile(char *devname);
 void do_monitor(struct supertype *container);
 void do_manager(struct supertype *container);
-extern int sigterm;
+extern volatile sig_atomic_t sigterm;
 
 int read_dev_state(int fd);
 bool is_container_member(struct mdstat_ent *mdstat, char *container);


### PR DESCRIPTION
Signals handlers can only read/write to volatile sig_atomic_t variables or atomic lock-free ones.
Anything else results in undefined behaviour.