### PR TITLE
mdadm/incremental: set sysfs name after assembling imsm array

### DIFF
--- a/Incremental.c
+++ b/Incremental.c
@@ -1494,6 +1494,7 @@ static int Incremental_container(struct supertype *st, char *devname,
 	for (ra = list ; ra ; ra = ra->next) {
 		int mdfd = -1;
 		char chosen_name[1024];
+		char *sysname;
 		struct map_ent *mp;
 		struct mddev_ident *match = NULL;
 
@@ -1586,6 +1587,8 @@ static int Incremental_container(struct supertype *st, char *devname,
 					   chosen_name, &result);
 		map_free(map);
 		map = NULL;
+		sysname = fd2devnm(mdfd);
+		strncpy(info.sys_name, sysname, sizeof(sysname) - 1);
 		close_fd(&mdfd);
 		udev_unblock();
 		sysfs_uevent(&info, "change");


### PR DESCRIPTION
The sysfs name is not set after assembling imsm array. So sysfs_uevent can't send the change event. The raid device's state depends on the genuine events from the kernel. If the kernel geniune event is sent after udev_unblock, the raid can be ready on time. Then the it can be mounted during boot rightly. If the kernel geniune event is sent before udev_unblock, the mount will fail during boot.