### PR TITLE
raid6check.c, restripe.c: Use 64-bit off_t across both musl and glibc

### DIFF
--- a/raid6check.c
+++ b/raid6check.c
@@ -288,7 +288,7 @@ int manual_repair(int chunk_size, int syndrome_disks,
 	}
 
 	int write_res1, write_res2;
-	off64_t seek_res;
+	off_t seek_res;
 
 	seek_res = lseek(source[fd1], offsets[fd1] + start * chunk_size, SEEK_SET);
 	if (seek_res < 0) {
@@ -381,7 +381,7 @@ int check_stripes(struct mdinfo *info, int *source, unsigned long long *offsets,
 			goto exitCheck;
 		}
 		for (i = 0 ; i < raid_disks ; i++) {
-			off64_t seek_res = lseek(source[i], offsets[i] + start * chunk_size,
+			off_t seek_res = lseek(source[i], offsets[i] + start * chunk_size,
 						   SEEK_SET);
 			if (seek_res < 0) {
 				fprintf(stderr, "lseek to source %d failed\n", i);

--- a/restripe.c
+++ b/restripe.c
@@ -756,7 +756,7 @@ int restore_stripes(int *dest, unsigned long long *offsets,
 			if (src_buf == NULL) {
 				/* read from file */
 				if (lseek(source, read_offset, 0) !=
-					 (off64_t)read_offset) {
+					 (off_t)read_offset) {
 					rv = -1;
 					goto abort;
 				}


### PR DESCRIPTION
This commit is adaptation of original patch[1] after commit[2] addressed lseek issues.

[1] https://lore.kernel.org/linux-raid/20221110225546.337164-1-raj.khem@gmail.com/
[2] https://github.com/md-raid-utilities/mdadm/commit/787cc1b60130b8031be59e49d54463c58cd8cf74

Fixes error:

| restripe.c:759:8: error: use of undeclared identifier 'off64_t'; did you mean 'off_t'?
|   759 |                                          (off64_t)read_offset) {                     
|       |                                           ^~~~~~~                     