### PR TITLE
super-ddf.c: the header search now use mmap

### DIFF
--- a/super-ddf.c
+++ b/super-ddf.c
@@ -33,6 +33,10 @@
 
 #include <values.h>
 #include <stddef.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
 /* a non-official T10 name for creation GUIDs */
 static char T10[] = "Linux-MD";
@@ -273,7 +277,7 @@ struct phys_disk {
 #define	DDF_Missing			64
 
 
-#define SEARCH_BLOCK_SIZE  4096
+#define SEARCH_BLOCK_SIZE  (1024 * 1024)
 #define SEARCH_REGION_SIZE (32 * 1024 * 1024)
 
 /* The content of the virt_section global scope */
@@ -893,82 +897,70 @@ static void *load_section(int fd, struct ddf_super *super, void *buf,
 static int search_for_ddf_headers(int fd, char *devname,
 				  unsigned long long *out)
 {
-	unsigned long long search_start;
-	unsigned long long search_end;
-	size_t bytes_block_to_read;
 	unsigned long long dsize;
-	unsigned long long pos;
-	int bytes_current_read;
-	size_t offset;
+	unsigned long long search_start;
+	size_t map_len;		  /* real search（<= 32MB） */
 
-	void *buffer = NULL;
-	be32 *magic_ptr = NULL;
+	long pagesz_l;
+	size_t pagesz;
 
+	unsigned long long map_off;   /* mmap offset，align to page */
+	size_t delta;				/*  search_start - map_off */
+	size_t map_len_adj;		  /* mmaplength = delta + map_len */
+
+	void *map = MAP_FAILED;
+	unsigned char *p;
 	int result = 0;
 
+	pagesz_l = sysconf(_SC_PAGESIZE);
+	pagesz = (pagesz_l > 0) ? (size_t)pagesz_l : 4096;
+
 	get_dev_size(fd, NULL, &dsize);
+	if (dsize == 0) {
+		pr_err("Device %s has size 0\n",
+			devname ? devname : "unknown");
+		return -ENODEV; /* empty device / unknown size */
+	}
+	if (dsize <= SEARCH_REGION_SIZE)
+		return 0; /* Size is inappropriate, though not erroneous. */
 
+	map_len =  (size_t)SEARCH_REGION_SIZE;
 
-	/* Determine the search range */
-	if (dsize > SEARCH_REGION_SIZE)
-		search_start = dsize - SEARCH_REGION_SIZE;
-	else
-		search_start = 0;
+	search_start = dsize - (unsigned long long)map_len;
 
-	search_end = dsize;
-	pos = search_start;
+	/* mmap offset align to page */
+	map_off = search_start & ~((unsigned long long)pagesz - 1ULL);
+	delta = (size_t)(search_start - map_off);
 
+	/* [search_start, search_start + map_len) */
+	map_len_adj = delta + map_len;
 
-	buffer = xmemalign(SEARCH_BLOCK_SIZE, SEARCH_BLOCK_SIZE);
-
-	if (buffer == NULL) {
-		result = 1;
-		goto cleanup;
+	map = mmap(NULL, map_len_adj, PROT_READ, MAP_SHARED, fd, (off_t)map_off);
+	if (map == MAP_FAILED) {
+		pr_err("mmap for %s failed %d:%s\n",
+		   fd2devnm(fd), errno, strerror(errno));
+		return -ENOMEM;
 	}
 
-	while (pos < search_end) {
-		/* Calculate the number of bytes to read in the current block */
-		bytes_block_to_read = SEARCH_BLOCK_SIZE;
-		if (search_end - pos < SEARCH_BLOCK_SIZE)
-			bytes_block_to_read = search_end - pos;
+	p = (unsigned char *)map + delta;
 
-		if (lseek(fd, pos, SEEK_SET) < 0) {
-			pr_err("lseek for %s failed %d:%s\n",
-				fd2devnm(fd), errno, strerror(errno));
-			result = 2;
+	for (size_t i = 0; i + sizeof(be32) <= map_len; i += sizeof(be32)) {
+		be32 v;
+
+		memcpy(&v, p + i, sizeof(v));   /* avoid unaligned access. */
+		if (be32_eq(v, DDF_HEADER_MAGIC)) {
+			*out = search_start + (unsigned long long)i;
+			result = 0;
 			goto cleanup;
 		}
-
-		/*Read data from the device */
-		bytes_current_read = read(fd, buffer, bytes_block_to_read);
-
-		if (bytes_current_read <= 0) {
-			pr_err("Failed to read %s. %d:%s, Position=%llu, Bytes to read=%zu. Skipping.\n",
-			       fd2devnm(fd), errno, strerror(errno), pos, bytes_block_to_read);
-			pos += SEARCH_BLOCK_SIZE;	/* Skip to the next block */
-			continue;
-		}
-
-		/* Search for the magic value within the read block */
-		for (offset = 0;
-		    offset + sizeof(be32) <= (size_t)bytes_current_read;
-		    offset += sizeof(be32)) {
-
-			magic_ptr = (be32 *) ((char *)buffer + offset);
-			if (be32_eq(*magic_ptr, DDF_HEADER_MAGIC)) {
-				*out = pos + offset;
-				result = 0;
-				goto cleanup;
-			}
-		}
-
-		pos += SEARCH_BLOCK_SIZE;
 	}
 
+	result = 0; /* Not found, returning normally.*/
 cleanup:
-	free(buffer);
+	munmap(map, map_len_adj);
 	return result;
 }
+
 
 static int load_ddf_headers(int fd, struct ddf_super *super, char *devname)
 {


### PR DESCRIPTION
Commit f2197b6b6c14 ("super-ddf: optimize DDF header search for widely
used RAID controllers")  introduces a heuristic search for DDF headers,
commonly written by RAID controllers, within the last 32MB of the disk.
However, the 4096-byte block size used for the search proved to be too
slow on network drives, leading to timeouts.

By modifying to use mmap, the responsibility of efficiently fetching
data is delegated to the kernel, thereby accelerating operations in a
remote disk environment.

Fix: Issue #238
