### PR TITLE
Use extended DDF header check only if configured to do so

### DIFF
--- a/config.c
+++ b/config.c
@@ -83,7 +83,7 @@ char DefaultAltConfDir[] = CONFFILE2 ".d";
 
 enum linetype { Devices, Array, Mailaddr, Mailfrom, Program, CreateDev,
 		Homehost, HomeCluster, AutoMode, Policy, PartPolicy, Sysfs,
-		MonitorDelay, EncryptionNoVerify, LTEnd };
+		MonitorDelay, EncryptionNoVerify, Probing, LTEnd };
 char *keywords[] = {
 	[Devices]  = "devices",
 	[Array]    = "array",
@@ -99,6 +99,7 @@ char *keywords[] = {
 	[Sysfs]    = "sysfs",
 	[MonitorDelay] = "monitordelay",
 	[EncryptionNoVerify] = "ENCRYPTION_NO_VERIFY",
+	[Probing] = "probing",
 	[LTEnd]    = NULL
 };
 
@@ -689,6 +690,19 @@ void encryption_no_verify_line(char *line)
 	}
 }
 
+static bool probing_ddf_extended;
+void probing_line(char *line)
+{
+	char *word;
+
+	for (word = dl_next(line); word != line; word = dl_next(word)) {
+		if (strcasecmp(word, "ddf_extended") == 0)
+			probing_ddf_extended = true;
+		else
+			pr_err("unrecognised word on PROBING line: %s\n", word);
+	}
+}
+
 char auto_yes[] = "yes";
 char auto_no[] = "no";
 char auto_homehost[] = "homehost";
@@ -876,6 +890,9 @@ void conf_file(FILE *f)
 		case EncryptionNoVerify:
 			encryption_no_verify_line(line);
 			break;
+		case Probing:
+			probing_line(line);
+			break;
 		default:
 			pr_err("Unknown keyword %s\n", line);
 		}
@@ -1043,6 +1060,12 @@ bool conf_get_sata_opal_encryption_no_verify(void)
 {
 	load_conffile();
 	return sata_opal_encryption_no_verify;
+}
+
+bool conf_get_probing_ddf_extended(void)
+{
+	load_conffile();
+	return probing_ddf_extended;
 }
 
 struct createinfo *conf_get_create_info(void)

--- a/mdadm.conf.5.in
+++ b/mdadm.conf.5.in
@@ -621,6 +621,19 @@ metadata.
 Available parameter
 .I "sata_opal".
 
+.TP
+.B PROBING
+The
+.B PROBING
+line provides options to configure device probing.
+.RS 4
+.TP
+.B ddf_extended
+Use extended algorithm to detect DDF headers on disks. Instead of looking for
+the DDF super block only in the last block of the device, scan the last 32
+MB. This allows detection of metadata created by some RAID controllers, at the
+cost of slower probing.
+.RE
 
 .SH FILES
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -1639,6 +1639,7 @@ extern char *conf_get_homehost(int *require_homehostp);
 extern char *conf_get_homecluster(void);
 extern int conf_get_monitor_delay(void);
 extern bool conf_get_sata_opal_encryption_no_verify(void);
+extern bool conf_get_probing_ddf_extended(void);
 extern char *conf_line(FILE *file);
 extern char *conf_word(FILE *file, int allow_key);
 extern void print_quoted(char *str);

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -1006,7 +1006,7 @@ static int load_ddf_headers(int fd, struct ddf_super *super, char *devname)
 		}
 	}
 
-	if (!found_anchor) {
+	if (!found_anchor && conf_get_probing_ddf_extended()) {
 		/* If not found, perform a full search for DDF headers */
 		ddffound = search_for_ddf_headers(fd, devname, &ddfpos);
 		if (ddffound != 0) {


### PR DESCRIPTION
This fixes #238 and is meant to used on top / in addition to  #240.

mdadm probing is used a lot in udev rules, also for devices which are not MD members in the first place. For such devices, mdadm probing will be slowed down considerably by always reading the last 32 MB of the device. The extended probing was added in f2197b6 in order to support non-spec-conforming DDF metadata as written by some RAID controllers. This is a useful feature, but it shouldn't slow down every probing attempt. Instead, add a configuration option

```
PROBING ddf_extended
```
which will enable the extended DDF header search.

CC: @slayercat, @bdrung, @mtkaczyk, @XiaoNi87