### PR TITLE
mdadm: fix bitmap check

### DIFF
--- a/mdadm.c
+++ b/mdadm.c
@@ -1575,8 +1575,10 @@ int main(int argc, char *argv[])
 		}
 
 		if (s.btype == BitmapUnknown) {
-			if (c.runstop != 1 && s.level >= 1 &&
-			    ask("To optimize recovery speed, it is recommended to enable write-intent bitmap, do you want to enable it now?"))
+			if (s.level == UnSet)
+				s.btype = BitmapNone;
+			else if (c.runstop != 1 && s.level >= 1 &&
+				 ask("To optimize recovery speed, it is recommended to enable write-intent bitmap, do you want to enable it now?"))
 				s.btype = BitmapInternal;
 			else
 				s.btype = BitmapNone;


### PR DESCRIPTION
Commit e97c4e18c84 ("mdadm: ask user if bitmap is not set") adds a prompt to the user regarding bitmap enabling during creation. However, the case of creating a container, where the bitmap is not meaningful, was omitted.

This may mislead the user, as attempting to enable bitmap ends with a container creation error: "mdadm: bitmaps not meaningful with level container"

At the stage where this check is performed, the level holds the UnSet value, LEVEL_CONTAINER is set at a later stage in Create.

The fix adds a check if the level is UnSet and set bitmap to BitmapNone, because this is the only acceptable value for the container. This check also covers the case when the level is not given during volume creation, as it makes no sense to ask for a bitmap without knowledge about level.