### PR TITLE
Add --trigger-check and --trigger-repair option to manage mode

### DIFF
--- a/Manage.c
+++ b/Manage.c
@@ -1856,3 +1856,27 @@ int move_spare(char *from_devname, char *to_devname, dev_t devid)
 	close_fd(&fd2);
 	return 0;
 }
+
+int Manage_trigger_check_repair(char *devname, int fd, int flag, int verbose)
+{
+	struct mdinfo info;
+	int rv = 0;
+
+	if (sysfs_init(&info, fd, NULL)) {
+		pr_err("sysfs not available for %s\n", devname);
+		return 1;
+	}
+
+	char *action = (flag == 0) ? "check" : "repair";
+
+	if (verbose > 0)
+		pr_info("Triggering %s on %s\n", action, devname);
+
+	if (sysfs_set_str(&info, NULL, "sync_action", action) < 0) {
+		pr_err("Failed to trigger %s on %s\n", action, devname);
+		rv = 1;
+	}
+
+	return rv;
+}
+

--- a/ReadMe.c
+++ b/ReadMe.c
@@ -178,6 +178,8 @@ struct option long_options[] = {
 	{"wait-clean", 0, 0, Waitclean},
 	{"action", 1, 0, Action},
 	{"cluster-confirm", 0, 0, ClusterConfirm},
+	{"trigger-check", 0, 0, TriggerCheck},
+	{"trigger-repair", 0, 0, TriggerRepair},
 
 	/* For Detail/Examine */
 	{"brief", 0, 0, Brief},
@@ -445,6 +447,8 @@ char Help_manage[] =
 "  --stop        -S   : deactivate array, releasing all resources\n"
 "  --readonly    -o   : mark array as readonly\n"
 "  --readwrite   -w   : mark array as readwrite\n"
+"  --trigger-check    : trigger a check operation on the array\n"
+"  --trigger-repair   : trigger a repair operation on the array\n"
 ;
 
 char Help_misc[] =

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -1451,11 +1451,11 @@ Subsequent devices that are added or re\-added will have the 'write-mostly'
 flag cleared.
 .TP
 .B \-\-trigger\-check
-Trigger a check operation on the array. This will start a read-only check 
+Trigger a check operation on the array. This will start a read-only check
 process to ensure all data is consistent across the devices.
 .TP
 .B \-\-trigger\-repair
-Trigger a repair operation on the array. This will start a repair 
+Trigger a repair operation on the array. This will start a repair
 process to ensure all data is consistent across the devices.
 .TP
 .BR \-\-cluster\-confirm

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -1450,6 +1450,14 @@ will avoid reading from these devices if possible.
 Subsequent devices that are added or re\-added will have the 'write-mostly'
 flag cleared.
 .TP
+.B \-\-trigger\-check
+Trigger a check operation on the array. This will start a read-only check 
+process to ensure all data is consistent across the devices.
+.TP
+.B \-\-trigger\-repair
+Trigger a repair operation on the array. This will start a repair 
+process to ensure all data is consistent across the devices.
+.TP
 .BR \-\-cluster\-confirm
 Confirm the existence of the device. This is issued in response to an \-\-add
 request by a node in a cluster. When a node adds a device it sends a message

--- a/mdadm.c
+++ b/mdadm.c
@@ -142,6 +142,8 @@ int main(int argc, char *argv[])
 	struct context c = {
 		.require_homehost = 1,
 		.metadata = NULL,
+		.trigger_check = 0,
+		.trigger_repair = 0,
 	};
 	struct shape s = {
 		.journaldisks	= 0,
@@ -1005,6 +1007,12 @@ int main(int argc, char *argv[])
 			}
 			devmode = 'W';
 			continue;
+		case O(MANAGE, TriggerCheck):
+			c.trigger_check = 1;
+			continue;
+		case O(MANAGE, TriggerRepair):
+			c.trigger_repair = 1;
+			continue;
 		case O(INCREMENTAL,'R'):
 		case O(MANAGE,'R'):
 		case O(ASSEMBLE,'R'):
@@ -1462,6 +1470,10 @@ int main(int argc, char *argv[])
 			rv = Manage_run(ident.devname, mdfd, &c);
 		if (!rv && c.runstop < 0)
 			rv = Manage_stop(ident.devname, mdfd, c.verbose, 0);
+		if (!rv && c.trigger_check)
+			rv = Manage_trigger_check_repair (ident.devname, mdfd, 0,  c.verbose);
+		if (!rv && c.trigger_repair)
+			rv = Manage_trigger_check_repair(ident.devname, mdfd, 1, c.verbose);
 		break;
 	case ASSEMBLE:
 		if (!c.scan && c.runstop == -1) {

--- a/mdadm.c
+++ b/mdadm.c
@@ -1471,7 +1471,7 @@ int main(int argc, char *argv[])
 		if (!rv && c.runstop < 0)
 			rv = Manage_stop(ident.devname, mdfd, c.verbose, 0);
 		if (!rv && c.trigger_check)
-			rv = Manage_trigger_check_repair (ident.devname, mdfd, 0,  c.verbose);
+			rv = Manage_trigger_check_repair(ident.devname, mdfd, 0,  c.verbose);
 		if (!rv && c.trigger_repair)
 			rv = Manage_trigger_check_repair(ident.devname, mdfd, 1, c.verbose);
 		break;

--- a/mdadm.h
+++ b/mdadm.h
@@ -499,6 +499,8 @@ enum special_options {
 	WriteJournal,
 	ConsistencyPolicy,
 	LogicalBlockSize,
+	TriggerCheck,
+	TriggerRepair,
 };
 
 enum update_opt {
@@ -641,6 +643,8 @@ struct context {
 	int	nodes;
 	char	*homecluster;
 	char	*metadata;
+	int	trigger_check;
+	int	trigger_repair;
 };
 
 struct shape {
@@ -1497,6 +1501,7 @@ extern int Manage_ro(char *devname, int fd, int readonly);
 extern int Manage_run(char *devname, int fd, struct context *c);
 extern int Manage_stop(char *devname, int fd, int quiet,
 		       int will_retry);
+extern int Manage_trigger_check_repair(char *devname, int fd, int flag, int verbose);
 extern int Manage_subdevs(char *devname, int fd,
 			  struct mddev_dev *devlist, int verbose, int test,
 			  enum update_opt update, int force);


### PR DESCRIPTION
This patch adds support for the --trigger-check and --trigger-repair option in mdadm's manage mode. The new options allows users to manually trigger a check or a repair operation on an MD array by setting the sync_action to 'check' or to 'repair' via sysfs.

Changes:
- Add TriggerCheck and TriggerRepair enum value field to context
- Add --trigger-check long option and parsing
- Add --trigger-repair long option and parsing
- Implement Manage_trigger_check_repair function
- Update help text and man page documentation

Usage: mdadm --manage /dev/md0 --trigger-check
Usage: mdadm --manage /dev/md0 --trigger-repair