### PR TITLE
Fix typo in lockless bitmap warning

### DIFF
--- a/mdadm.c
+++ b/mdadm.c
@@ -59,7 +59,7 @@ static mdadm_status_t set_bitmap_value(struct shape *s, struct context *c, char 
 
 	if (strcmp(val, "lockless") == 0) {
 		s->btype = BitmapLockless;
-		pr_info("Experimental lockless bitmap, use at your own disk!\n");
+		pr_info("Experimental lockless bitmap, use at your own risk!\n");
 		return MDADM_STATUS_SUCCESS;
 	}
 


### PR DESCRIPTION
cc: @YuKuai-huawei
