### PR TITLE
Avoid int overflow after year 2038

### DIFF
--- a/util.c
+++ b/util.c
@@ -634,7 +634,7 @@ int check_ext2(int fd, char *name)
 	if (sb[56] != 0x53 || sb[57] != 0xef)
 		return 0;
 
-	mtime = sb[44]|(sb[45]|(sb[46]|sb[47]<<8)<<8)<<8;
+	mtime = sb[44]|(sb[45]|(sb[46]|(unsigned int)sb[47]<<8)<<8)<<8;
 	bsize = sb[24]|(sb[25]|(sb[26]|sb[27]<<8)<<8)<<8;
 	size = sb[4]|(sb[5]|(sb[6]|sb[7]<<8)<<8)<<8;
 	size <<= bsize;


### PR DESCRIPTION
Avoid int overflow after year 2038, so it can work until year 2106. Note: dates before 1970 will stop working.

See https://en.wikipedia.org/wiki/Year_2038_problem

This patch was done while reviewing potential year-2038 issues in openSUSE.