### PR TITLE
clustermd_tests: control speed limits on both nodes

### DIFF
--- a/clustermd_tests/func.sh
+++ b/clustermd_tests/func.sh
@@ -169,20 +169,58 @@ stop_md()
 }
 
 record_system_speed_limit() {
-	system_speed_limit_max=`cat /proc/sys/dev/raid/speed_limit_max`
-	system_speed_limit_min=`cat /proc/sys/dev/raid/speed_limit_min`
+	local ip
+	local idx=0
+
+	for ip in $NODE1 $NODE2
+	do
+		nodes_system_speed_limit_min[$idx]=$(ssh $ip "cat /proc/sys/dev/raid/speed_limit_min")
+		nodes_system_speed_limit_max[$idx]=$(ssh $ip "cat /proc/sys/dev/raid/speed_limit_max")
+		idx=$[idx+1]
+	done
 }
 
 # To avoid sync action finishes before checking it, it needs to limit
 # the sync speed
 control_system_speed_limit() {
-	echo $test_speed_limit_min > /proc/sys/dev/raid/speed_limit_min
-	echo $test_speed_limit_max > /proc/sys/dev/raid/speed_limit_max
+	local ip
+	local idx=0
+
+	for ip in $NODE1 $NODE2
+	do
+		ssh $ip "echo ${nodes_test_speed_limit_min[$idx]} > /proc/sys/dev/raid/speed_limit_min"
+		ssh $ip "echo ${nodes_test_speed_limit_max[$idx]} > /proc/sys/dev/raid/speed_limit_max"
+		idx=$[idx+1]
+	done
 }
 
 restore_system_speed_limit() {
-	echo $system_speed_limit_min > /proc/sys/dev/raid/speed_limit_max
-	echo $system_speed_limit_max > /proc/sys/dev/raid/speed_limit_max
+	local ip
+	local idx=0
+	local min
+	local max
+
+	for ip in $NODE1 $NODE2
+	do
+		min=${nodes_system_speed_limit_min[$idx]}
+		max=${nodes_system_speed_limit_max[$idx]}
+
+		if [ -z "$min" ]
+		then
+			echo "$ip: speed_limit_min was not recorded, skip restoring." >> $targetdir/log
+		else
+			ssh $ip "echo $min > /proc/sys/dev/raid/speed_limit_min"
+		fi
+
+		if [ -z "$max" ]
+		then
+			echo "$ip: speed_limit_max was not recorded, skip restoring." >> $targetdir/log
+		else
+			ssh $ip "echo $max > /proc/sys/dev/raid/speed_limit_max"
+		fi
+
+		idx=$[idx+1]
+	done
 }
 
 record_selinux() {
@@ -238,6 +276,7 @@ do_setup()
 {
 	check_env
 	ulimit -c unlimited
+	record_system_speed_limit
 }
 
 do_clean()

--- a/test
+++ b/test
@@ -6,10 +6,20 @@ targetdir="/var/tmp"
 logdir="$targetdir"
 config=/tmp/mdadm.conf
 testdir=$PWD/tests
+
+# used by tests
 system_speed_limit_max=0
 system_speed_limit_min=0
 test_speed_limit_min=100
 test_speed_limit_max=500
+
+# used by clustermd_tests
+nodes_system_speed_limit_min=()
+nodes_system_speed_limit_max=()
+# NODE1, NODE2
+nodes_test_speed_limit_min=(100 1000)
+nodes_test_speed_limit_max=(500 100000)
+
 devlist=
 # If super1 metadata name doesn't have the same hostname with machine,
 # it's treated as foreign.


### PR DESCRIPTION
Before this commit, record_system_speed_limit() in clustermd_tests/func.sh is never called, but restore_system_speed_limit() is always called. Which means the original system speed limits cannot be restored.

The second issue is that clustermd_tests/func.sh:control_system_speed_limit() only sets local machine's speed_limit_min and speed_limit_max but remote node won't be influenced. This causes some cases like 03r1_switch-recovery to fail because the expected operation may have been done before check.

Here introduce array nodes_test_speed_limit_min and nodes_test_speed_limit_max to set raid sync speed limits for NODE1 and NODE2. nodes_system_speed_limit_min and nodes_system_speed_limit_max are for recording origin values.

NOTE: test_speed_limit_min and test_speed_limit_max are not used by clustermd_tests anymore. Many clustermd tests require slow speed on NODE1 but faster speed on NODE2 so nodes_test_speed_limit_min and nodes_test_speed_limit_max are necessary.

Assisted-by: Codex:gpt-5.5
Signed-off-by: Su Yue <glass.su@suse.com>