### PR TITLE
mdadm: Fix memory leak in Detail

### DIFF
--- a/Detail.c
+++ b/Detail.c
@@ -799,8 +799,6 @@ skip_devices_state:
 		printf(" spares=%d", spares);
 	if (c->brief && st && st->sb)
 		st->ss->brief_detail_super(st, subarray);
-	if (st)
-		st->ss->free_super(st);
 
 	if (c->brief && c->verbose > 0 && devices) {
 		qsort(devices, n_devices, sizeof(*devices), cmpstringp);
@@ -825,6 +823,8 @@ out:
 			free(devices[d]);
 	free(devices);
 	sysfs_free(sra);
+	if (st)
+		st->ss->free_super(st);
 	free(st);
 	return rv;
 }


### PR DESCRIPTION
The supertype 'st' allocated in Detail.c is not freed properly in the error paths. Move the free_super call to the end of the function to ensure 'st' is always freed, preventing memory leaks.