### PR TITLE
mdadm: Query.c use sysfs_free() for proper resource cleanup

### DIFF
--- a/Query.c
+++ b/Query.c
@@ -134,7 +134,7 @@ int Query(char *dev)
 		if (st->ss == &super0)
 			put_md_name(mddev);
 	}
-	free(sra);
+	sysfs_free(sra);
 
 	return 0;
 }


### PR DESCRIPTION
```
free(sra) against mdinfo object allocated by sysfs_read() in Query.c can 
cause improper cleanup before return. This change uses sysfs_free() 
instead which should do proper cleanup of the object.

Fixes: bcc3ab1728da ("mdadm: Query.c fix coverity issues")
```