### PR TITLE
Fix imsm regression

### DIFF
--- a/config.c
+++ b/config.c
@@ -83,7 +83,7 @@ char DefaultAltConfDir[] = CONFFILE2 ".d";
 
 enum linetype { Devices, Array, Mailaddr, Mailfrom, Program, CreateDev,
 		Homehost, HomeCluster, AutoMode, Policy, PartPolicy, Sysfs,
-		MonitorDelay, EncryptionNoVerify, Probing, LTEnd };
+		MonitorDelay, EncryptionNoVerify, Probing, ImsmDisableOrom, LTEnd };
 char *keywords[] = {
 	[Devices]  = "devices",
 	[Array]    = "array",
@@ -100,6 +100,7 @@ char *keywords[] = {
 	[MonitorDelay] = "monitordelay",
 	[EncryptionNoVerify] = "ENCRYPTION_NO_VERIFY",
 	[Probing] = "probing",
+	[ImsmDisableOrom] = "IMSM_DISABLE_OROM",
 	[LTEnd]    = NULL
 };
 
@@ -703,6 +704,21 @@ void probing_line(char *line)
 	}
 }
 
+static bool imsm_disable_orom;
+void imsm_disable_orom_line(char *line)
+{
+	char *word;
+
+	for (word = dl_next(line); word != line; word = dl_next(word)) {
+		if (strcmp(word, "1") == 0)
+			imsm_disable_orom = true;
+		else if (strcmp(word, "0") == 0)
+			imsm_disable_orom = false;
+		else
+			pr_err("unrecognised value on IMSM_DISABLE_OROM line: %s\n", word);
+	}
+}
+
 char auto_yes[] = "yes";
 char auto_no[] = "no";
 char auto_homehost[] = "homehost";
@@ -893,6 +909,9 @@ void conf_file(FILE *f)
 		case Probing:
 			probing_line(line);
 			break;
+		case ImsmDisableOrom:
+			imsm_disable_orom_line(line);
+			break;
 		default:
 			pr_err("Unknown keyword %s\n", line);
 		}
@@ -1066,6 +1085,12 @@ bool conf_get_probing_ddf_extended(void)
 {
 	load_conffile();
 	return probing_ddf_extended;
+}
+
+bool conf_get_imsm_disable_orom(void)
+{
+	load_conffile();
+	return imsm_disable_orom;
 }
 
 struct createinfo *conf_get_create_info(void)

--- a/mdadm.conf.5.in
+++ b/mdadm.conf.5.in
@@ -635,6 +635,27 @@ MB. This allows detection of metadata created by some RAID controllers, at the
 cost of slower probing.
 .RE
 
+.TP
+.B IMSM_DISABLE_OROM
+The
+.B IMSM_DISABLE_OROM
+option controls whether
+.I mdadm
+scans option-ROM (OROM) memory to detect IMSM capabilities.
+By default, when neither EFI nor ACPI capabilities are found,
+.I mdadm
+falls back to scanning option-ROM memory.
+When set to
+.IR 1 ,
+the OROM scan is skipped.
+When set to
+.I 0
+(the default), the scan proceeds normally.
+
+This option is useful on systems with kernel lockdown enabled to avoid log flooding.
+The OROM scan is a legacy method of detecting IMSM capabilities, superseded by EFI variables,
+and can usually be disabled safely on modern UEFI systems.
+
 .SH FILES
 
 .SS {CONFFILE}

--- a/mdadm.h
+++ b/mdadm.h
@@ -1640,6 +1640,7 @@ extern char *conf_get_homecluster(void);
 extern int conf_get_monitor_delay(void);
 extern bool conf_get_sata_opal_encryption_no_verify(void);
 extern bool conf_get_probing_ddf_extended(void);
+extern bool conf_get_imsm_disable_orom(void);
 extern char *conf_line(FILE *file);
 extern char *conf_word(FILE *file, int allow_key);
 extern void print_quoted(char *str);

--- a/platform-intel.c
+++ b/platform-intel.c
@@ -621,7 +621,6 @@ const struct imsm_orom *imsm_platform_test(struct sys_dev *hba)
 
 static const struct imsm_orom *find_imsm_hba_orom(struct sys_dev *hba)
 {
-	struct stat st;
 	unsigned long align;
 
 	if (check_env("IMSM_TEST_OROM"))
@@ -629,10 +628,6 @@ static const struct imsm_orom *find_imsm_hba_orom(struct sys_dev *hba)
 
 	/* return empty OROM capabilities in EFI test mode */
 	if (check_env("IMSM_TEST_AHCI_EFI") || check_env("IMSM_TEST_SCU_EFI"))
-		return NULL;
-
-	/* Skip legacy option ROM scan when EFI booted */
-	if (stat("/sys/firmware/efi", &st) == 0 && S_ISDIR(st.st_mode))
 		return NULL;
 
 	find_intel_devices();

--- a/platform-intel.c
+++ b/platform-intel.c
@@ -623,6 +623,9 @@ static const struct imsm_orom *find_imsm_hba_orom(struct sys_dev *hba)
 {
 	unsigned long align;
 
+	if (conf_get_imsm_disable_orom())
+		return NULL;
+
 	if (check_env("IMSM_TEST_OROM"))
 		return imsm_platform_test(hba);
 


### PR DESCRIPTION
Reverting direct check for efi vars and allowing the same behavior by config option to keep a room for UEFI systems with no IMSM variables, obviously it is still a case for some folks.

Fixes: #268 