### PR TITLE
super-ddf: fix Heap OOB read in load_ddf_local()

### DIFF
--- a/super-ddf.c
+++ b/super-ddf.c
@@ -1242,9 +1242,18 @@ static int load_ddf_local(int fd, struct ddf_super *super,
 			    0);
 	super->conf = conf;
 	vnum = 0;
+	unsigned int sec_len =
+		be32_to_cpu(super->active->config_section_length);
+
+	if (super->conf_rec_len == 0 || super->conf_rec_len > sec_len) {
+		pr_err("ddf: Invalid configuration record length in metadata\n");
+		free(conf);
+		return 1;
+	}
+
 	for (confsec = 0;
-	     confsec < be32_to_cpu(super->active->config_section_length);
-	     confsec += super->conf_rec_len) {
+	    confsec + super->conf_rec_len <= sec_len;
+	    confsec += super->conf_rec_len) {
 		struct vd_config *vd =
 			(struct vd_config *)((char*)conf + confsec*512);
 		struct vcl *vcl;


### PR DESCRIPTION
When iterating over config section records in load_ddf_local(), the loop condition only checks if the start offset (confsec) is within config_section_length. If config_section_length is not an exact multiple of conf_rec_len, the final iteration reads past the end of the allocated buffer when performing memcpy and structure field accesses.

Fix this by ensuring conf_rec_len is non-zero and updating the loop condition to require that the entire record fits within config_section_length.