### PR TITLE
imsm: support data_offset for first volume

### DIFF
--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -843,10 +843,10 @@ being reshaped.
 
 .TP
 .B \-\-data\-offset=
-Arrays with 1.x metadata can leave a gap between the start of the
-device and the start of array data.  This gap can be used for various
-metadata.  The start of data is known as the
+Arrays with 1.x and IMSM metadata can leave a gap between the start of the
+device and the start of array data.  The start of data is called as the
 .IR data\-offset .
+
 Normally an appropriate data offset is computed automatically.
 However it can be useful to set it explicitly such as when re-creating
 an array which was originally created using a different version of
@@ -858,7 +858,7 @@ is in Kilobytes unless a suffix of 'K', 'M', 'G' or 'T' is used to explicitly
 indicate Kilobytes, Megabytes, Gigabytes or Terabytes respectively.
 
 .B \-\-data\-offset
-can also be used with
+for native 1.x can also be used with
 .B --grow
 for some RAID levels (initially on RAID10).  This allows the
 data\-offset to be changed as part of the reshape process.  When the
@@ -869,7 +869,7 @@ When the new offset is earlier than the old offset, the number of
 devices in the array cannot shrink.  When it is after the old offset,
 the number of devices in the array cannot increase.
 
-When creating an array,
+When creating an native 1.x array,
 .B \-\-data\-offset
 can be specified as
 .BR variable .
@@ -879,6 +879,13 @@ exactly an array which has varying data offsets (as can happen when
 different versions of
 .I mdadm
 are used to add different devices).
+
+For IMSM
+.B \-\-data\-offset
+can be set only when first volume in the array is created. Changing it with
+.B --grow
+and variable offset is not supported. It is useful to avoid finding partition table
+directly on member drives. The default offset is 0, raid volume starts in the first device sector.
 
 .TP
 .BR \-N ", " \-\-name=

--- a/super-intel.c
+++ b/super-intel.c
@@ -5780,7 +5780,11 @@ static int init_super_imsm_volume(struct supertype *st, mdu_array_info_t *info,
 	vol->dirty = !info->state;
 	set_vol_curr_migr_unit(dev, 0);
 	map = get_imsm_map(dev, MAP_0);
-	set_pba_of_lba0(map, super->create_offset);
+
+	if (data_offset == INVALID_SECTORS)
+		data_offset = 0;
+	set_pba_of_lba0(map, super->create_offset + data_offset);
+
 	map->blocks_per_strip = __cpu_to_le16(info_to_blocks_per_strip(info));
 	map->failed_disk_num = ~0;
 	if (info->level > IMSM_T_RAID0)
@@ -5856,8 +5860,8 @@ static int init_super_imsm(struct supertype *st, mdu_array_info_t *info,
 	struct imsm_super *mpb;
 	size_t mpb_size;
 
-	if (data_offset != INVALID_SECTORS) {
-		pr_err("data-offset not supported by imsm\n");
+	if (data_offset == VARIABLE_OFFSET) {
+		pr_err("imsm does not support variable data offset\n");
 		return 0;
 	}
 
@@ -7532,6 +7536,17 @@ static int validate_geometry_imsm_volume(struct supertype *st, int level,
 		pr_err("RAID geometry validation failed. Cannot proceed with the action(s).\n");
 		return 0;
 	}
+
+	if (data_offset != INVALID_SECTORS && mpb->num_raid_devs > 0) {
+		/* Volume offset is requested. This is supported only for first volume */
+		pr_vrb("Data offset is supported only for first volume\n");
+		return 0;
+	} else if (data_offset == INVALID_SECTORS) {
+		/* Act like there is no offset for calculations */
+		data_offset = 0;
+	}
+	/* VARIABLE_OFFSET is rejected in init_super_imsm_volume */
+
 	if (!dev) {
 		/* General test:  make sure there is space for
 		 * 'raiddisks' device extents of size 'size' at a given
@@ -7626,10 +7641,9 @@ static int validate_geometry_imsm_volume(struct supertype *st, int level,
 				dev);
 		return 0;
 	}
-	if (maxsize < size) {
-		if (verbose)
-			pr_err("%s not enough space (%llu < %llu)\n",
-				dev, maxsize, size);
+	if (maxsize < (data_offset + size)) {
+		pr_vrb("%s: not enough space for volume with offset %llu, and size %llu\n"
+			"The max space is %llu\n", dev, data_offset, size, maxsize);
 		return 0;
 	}
 
@@ -7638,14 +7652,12 @@ static int validate_geometry_imsm_volume(struct supertype *st, int level,
 	if (mpb->num_raid_devs > 0 && size && size != maxsize)
 		pr_err("attempting to create a second volume with size less then remaining space.\n");
 
-	if (maxsize < size || maxsize == 0) {
-		if (verbose) {
-			if (maxsize == 0)
-				pr_err("no free space left on device. Aborting...\n");
-			else
-				pr_err("not enough space to create volume of given size (%llu < %llu). Aborting...\n",
-						maxsize, size);
-		}
+	if (maxsize < (data_offset + size) || maxsize == 0) {
+		if (maxsize == 0)
+			pr_vrb("no free space left on device. Aborting...\n");
+		else
+			pr_vrb("%s: not enough space for volume with offset %llu, and size %llu\n"
+				"The max space is %llu\n", dev, data_offset, size, maxsize);
 		return 0;
 	}
 
@@ -7681,6 +7693,7 @@ static int validate_geometry_imsm_volume(struct supertype *st, int level,
 static imsm_status_t imsm_get_free_size(struct intel_super *super,
 					const int raiddisks,
 					unsigned long long size,
+					unsigned long long data_offset,
 					const int chunk,
 					unsigned long long *freesize,
 					bool expanding)
@@ -7692,7 +7705,7 @@ static imsm_status_t imsm_get_free_size(struct intel_super *super,
 	int cnt = 0;
 	int used = 0;
 	unsigned long long maxsize;
-	unsigned long long minsize = size;
+	unsigned long long minsize = size + data_offset;
 
 	if (minsize == 0)
 		minsize = chunk * 2;
@@ -7754,6 +7767,7 @@ static imsm_status_t imsm_get_free_size(struct intel_super *super,
  * @super: &intel_super pointer, not NULL.
  * @raiddisks: number of raid disks.
  * @size: requested size, could be 0 (means max size).
+ * @data_offset: data offset in sectors, or INVALID_SECTORS.
  * @chunk: requested chunk.
  * @freesize: pointer for returned size value.
  *
@@ -7770,7 +7784,9 @@ static imsm_status_t imsm_get_free_size(struct intel_super *super,
  */
 static imsm_status_t autolayout_imsm(struct intel_super *super,
 				     const int raiddisks,
-				     unsigned long long size, const int chunk,
+				     unsigned long long size,
+				     unsigned long long data_offset,
+				     const int chunk,
 				     unsigned long long *freesize)
 {
 	int curr_slot = 0;
@@ -7778,7 +7794,16 @@ static imsm_status_t autolayout_imsm(struct intel_super *super,
 	int vol_cnt = super->anchor->num_raid_devs;
 	imsm_status_t rv;
 
-	rv = imsm_get_free_size(super, raiddisks, size, chunk, freesize, false);
+	if (data_offset != INVALID_SECTORS && vol_cnt > 0) {
+		/* Volume offset is requested. This is supported only for first volume */
+		pr_err("Data offset is supported only for first volume\n");
+		return IMSM_STATUS_ERROR;
+	} else if (data_offset == INVALID_SECTORS) {
+		/* Act like there is no offset for calculations */
+		data_offset = 0;
+	}
+
+	rv = imsm_get_free_size(super, raiddisks, size, data_offset, chunk, freesize, false);
 	if (rv != IMSM_STATUS_OK)
 		return IMSM_STATUS_ERROR;
 
@@ -7867,14 +7892,14 @@ static int validate_geometry_imsm(struct supertype *st, int level, int layout,
 		}
 
 		if (freesize) {
-			rv = autolayout_imsm(super, raiddisks, size, *chunk, freesize);
+			rv = autolayout_imsm(super, raiddisks, size, data_offset, *chunk, freesize);
 				if (rv != IMSM_STATUS_OK)
 					return 0;
 		}
 
 		return 1;
 	}
-	if (st->sb) {
+	if (super) {
 		/* creating in a given container */
 		return validate_geometry_imsm_volume(st, level, layout,
 						     raiddisks, chunk, size,
@@ -11960,7 +11985,8 @@ static imsm_status_t imsm_analyze_expand(struct supertype *st,
 	}
 	current_size = array->custom_array_size / data_disks;
 
-	rv = imsm_get_free_size(super, dev->vol.map->num_members, 0, chunk_kib, &free_size, true);
+	rv = imsm_get_free_size(super, dev->vol.map->num_members, 0, 0, chunk_kib,
+				&free_size, true);
 	if (rv != IMSM_STATUS_OK) {
 		pr_err("imsm: Cannot find free space for expand.\n");
 		return IMSM_STATUS_ERROR;

--- a/tests/09imsm-data-offset
+++ b/tests/09imsm-data-offset
@@ -1,0 +1,92 @@
+DEVS="$dev0 $dev1"
+
+# Verify Sector Offset in mdadm -E output matches expected sectors.
+check_sector_offset() {
+	local dev="$1"
+	local expected="$2"
+	local actual
+	actual=$(./mdadm -E "$dev" | awk '/Sector Offset/ {print $NF}')
+	[[ "$actual" != "$expected" ]] && echo "Test failed: Sector Offset expected $expected, got $actual" && exit 1
+}
+
+mdadm -Ss
+
+mdadm -CR imsm -e imsm -n2 $DEVS
+[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1
+
+# Creating volume with offset by devs
+mdadm -CR vol -l0 --run --data-offset=2G -z 3M -n 2 $DEVS
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
+
+# Creating imsm container and volume with offset and autolayout
+mdadm -CR vol -l0 --run --data-offset=2G -z 3M -n 2 "/dev/md/imsm"
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
+
+# Creating volume with big size by devs
+mdadm -CR vol -l0 --run --data-offset=2M -z 2G -n 2 $DEVS
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
+
+# Creating volume with big size by autolayout
+mdadm -CR vol -l0 --run --data-offset=2M -z 2G -n 2 "/dev/md/imsm"
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
+
+
+# Creating volume with acceptable offset and size by devs
+mdadm -CR vol -l0 --run --data-offset=2M -z 800M -n 2 $DEVS
+[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with offset" && exit 1
+check_sector_offset "$dev0" 4096
+
+mdadm -Ss
+
+mdadm -CR imsm -e imsm -n2 $DEVS
+[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1
+
+# Creating volume with acceptable offset and size by autolayout
+mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 "/dev/md/imsm"
+[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with offset" && exit 1
+check_sector_offset "$dev0" 4096
+
+
+# Creating second volume with offset by devs
+mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 $DEVS
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create second volume with offset" && exit 1
+
+# Creating second volume with offset by autolayout
+mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 "/dev/md/imsm"
+[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create second volume with offset" && exit 1
+
+mdadm -Ss
+
+mdadm -CR imsm -e imsm -n2 $DEVS
+[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1
+
+# Check if no offset works correctly
+mdadm -CR vol -l0 --run -z 3M -n 2 $DEVS
+[[ $? -ne 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
+check_sector_offset "$dev0" 0
+
+
+mdadm -Ss
+
+mdadm -CR imsm -e imsm -n2 $DEVS
+[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1
+
+
+# Creating imsm container and volume with no offset by devs
+mdadm -CR vol -l0 --run -z 3M -n 2 $DEVS
+[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with no offset" && exit 1
+check_sector_offset "$dev0" 0
+
+
+mdadm -Ss
+
+mdadm -CR imsm -e imsm -n2 $DEVS
+[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1
+
+# Creating imsm container and volume with no offset by autolayout
+mdadm -CR vol -l0 --run -z 3M -n 2 "/dev/md/imsm"
+[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with no offset" && exit 1
+check_sector_offset "$dev0" 0
+
+
+echo "PASSED"


### PR DESCRIPTION
If requested and first volume is created data_offset can be respected. To match it to "extends" logic, data_offset is added to whole expected size assuming that extend for first raid device is always positioned at first sector of underlaying block device.

The imsm validation code is complex. It is not attempting to make it robustly secure. It fits to regular imsm create design for both autolayout and dev listed modes.


Tested by script:
```bash
#!/bin/bash
set -x

# 1GB drives are used
DEV0="/dev/test-disk0"
DEV1="/dev/test-disk1"

DEVS="$DEV0 $DEV1"

# Verify Sector Offset in mdadm -E output matches expected sectors.
check_sector_offset() {
	local dev="$1"
	local expected="$2"
	local actual
	actual=$(./mdadm -E "$dev" | awk '/Sector Offset/ {print $NF}')
	[[ "$actual" != "$expected" ]] && echo "Test failed: Sector Offset expected $expected, got $actual" && exit 1
}

mdadm -Ss

./mdadm -CR imsm -e imsm -n2 $DEVS
[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1

echo "TEST1 - Creating volume with offset by devs"
./mdadm -CR vol -l0 --run --data-offset=2G -z 3M -n 2 $DEVS
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1

echo "TEST2 - Creating imsm container and volume with offset and autolayout"
./mdadm -CR vol -l0 --run --data-offset=2G -z 3M -n 2 "/dev/md/imsm"
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1

echo "TEST3 - Creating volume with big size by devs"
./mdadm -CR vol -l0 --run --data-offset=2M -z 2G -n 2 $DEVS
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1

echo "TEST4 - Creating volume with big size by autolayout"
./mdadm -CR vol -l0 --run --data-offset=2M -z 2G -n 2 "/dev/md/imsm"
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1


echo "TEST5 - Creating volume with acceptable offset and size by devs"
./mdadm -CR vol -l0 --run --data-offset=2M -z 800M -n 2 $DEVS
[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with offset" && exit 1
check_sector_offset "$DEV0" 4096

mdadm -Ss

./mdadm -CR imsm -e imsm -n2 $DEVS
[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1

echo "TEST6 - Creating volume with acceptable offset and size by autolayout"
./mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 "/dev/md/imsm"
[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with offset" && exit 1
check_sector_offset "$DEV0" 4096


echo "TEST7 - Creating second volume with offset by devs"
./mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 $DEVS
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create second volume with offset" && exit 1

echo "TEST8 - Creating second volume with offset by autolayout"
./mdadm -CR vol -l0 --run --data-offset=2M -z 300M -n 2 "/dev/md/imsm"
[[ $? -eq 0 ]] && echo "Test failed: mdadm should have failed to create second volume with offset" && exit 1

mdadm -Ss

./mdadm -CR imsm -e imsm -n2 $DEVS
[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1

echo "TEST9 - Check if no offset works correctly"
./mdadm -CR vol -l0 --run -z 3M -n 2 $DEVS
[[ $? -ne 0 ]] && echo "Test failed: mdadm should have failed to create volume with offset" && exit 1
check_sector_offset "$DEV0" 0


mdadm -Ss

./mdadm -CR imsm -e imsm -n2 $DEVS
[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1


echo "TEST10 - Creating imsm container and volume with no offset by devs"
./mdadm -CR vol -l0 --run -z 3M -n 2 $DEVS
[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with no offset" && exit 1
check_sector_offset "$DEV0" 0


mdadm -Ss

./mdadm -CR imsm -e imsm -n2 $DEVS
[[ $? -ne 0 ]] && echo "Failed to create imsm container" && exit 1

echo "TEST11 - Creating imsm container and volume with no offset by autolayout"
./mdadm -CR vol -l0 --run -z 3M -n 2 "/dev/md/imsm"
[[ $? -ne 0 ]] && echo "Test failed: mdadm should create volume with no offset" && exit 1
check_sector_offset "$DEV0" 0


echo "PASSED"
```