### PR TITLE
super-ddf: clamp max_pd_entries in load_ddf_local to prevent OOB read

### DIFF
--- a/super-ddf.c
+++ b/super-ddf.c
@@ -1195,6 +1195,7 @@ static int load_ddf_local(int fd, struct ddf_super *super,
 	int vnum;
 	unsigned int max_virt_disks =
 		be16_to_cpu(super->active->max_vd_entries);
+	unsigned int max_pdes;
 	unsigned long long dsize;
 
 	/* First the local disk info */
@@ -1237,7 +1238,12 @@ static int load_ddf_local(int fd, struct ddf_super *super,
 		dl->vlist[i] = NULL;
 	super->dlist = dl;
 	dl->pdnum = -1;
-	for (i = 0; i < be16_to_cpu(super->active->max_pd_entries); i++)
+	max_pdes = ddf_safe_entry_count(super->pdsize,
+			offsetof(struct phys_disk, entries),
+			sizeof(super->phys->entries[0]),
+			be16_to_cpu(super->active->max_pd_entries));
+
+	for (i = 0; i < max_pdes; i++)
 		if (memcmp(super->phys->entries[i].guid,
 			   dl->disk.guid, DDF_GUID_LEN) == 0)
 			dl->pdnum = i;

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -1237,10 +1237,17 @@ static int load_ddf_local(int fd, struct ddf_super *super,
 		dl->vlist[i] = NULL;
 	super->dlist = dl;
 	dl->pdnum = -1;
-	for (i = 0; i < be16_to_cpu(super->active->max_pd_entries); i++)
-		if (memcmp(super->phys->entries[i].guid,
-			   dl->disk.guid, DDF_GUID_LEN) == 0)
-			dl->pdnum = i;
+	{
+		unsigned int max_pdes = ddf_safe_entry_count(super->pdsize,
+				offsetof(struct phys_disk, entries),
+				sizeof(super->phys->entries[0]),
+				be16_to_cpu(super->active->max_pd_entries));
+
+		for (i = 0; i < max_pdes; i++)
+			if (memcmp(super->phys->entries[i].guid,
+				   dl->disk.guid, DDF_GUID_LEN) == 0)
+				dl->pdnum = i;
+	}
 
 	/* Now the config list. */
 	/* 'conf' is an array of config entries, some of which are


### PR DESCRIPTION
max_pd_entries is taken from an untrusted DDF header without clamping it to the actual size of the phys_section. This could lead to a heap out-of-bounds read when iterating over phys_disk entries.

Use ddf_safe_entry_count() to clamp the loop boundary.