### PR TITLE
Examine: Add rsync offset for native

### DIFF
--- a/super0.c
+++ b/super0.c
@@ -186,6 +186,10 @@ static void examine_super0(struct supertype *st, char *homehost)
 	printf("    Update Time : %.24s\n", ctime(&atime));
 	printf("          State : %s\n",
 	       (sb->state&(1 << MD_SB_CLEAN)) ? "clean":"active");
+	/* recovery_cp is a legacy name, from before sync actions got split */
+	if (sb->recovery_cp != (__u32)MaxSector)
+		printf("  Resync Offset : %llu sectors\n",
+		       (unsigned long long)sb->recovery_cp);
 	if (sb->state & (1 << MD_SB_BITMAP_PRESENT))
 		printf("Internal Bitmap : present\n");
 	printf(" Active Devices : %d\n", sb->active_disks);

--- a/super1.c
+++ b/super1.c
@@ -298,6 +298,9 @@ static void examine_super1(struct supertype *st, char *homehost)
 	if (__le32_to_cpu(sb->feature_map) & MD_FEATURE_RECOVERY_OFFSET)
 		printf("Recovery Offset : %llu sectors\n",
 		       (unsigned long long)__le64_to_cpu(sb->recovery_offset));
+	if (__le64_to_cpu(sb->resync_offset) != MaxSector)
+		printf("  Resync Offset : %llu sectors\n",
+		       (unsigned long long)__le64_to_cpu(sb->resync_offset));
 
 	st->ss->getinfo_super(st, &info, NULL);
 	if (info.space_after != 1 &&


### PR DESCRIPTION
During rebuild, mdadm examine will display "Recovery Offset" entry if recovery is active. Add displaying "Resync Offset" for 0.90 and 1.x so the behavior is consistent. Usefull for checking resync progress on offline array.