### PR TITLE
super1: validate max_dev heap

### DIFF
--- a/super1.c
+++ b/super1.c
@@ -2207,6 +2207,14 @@ static int load_super1(struct supertype *st, int fd, char *devname)
 		return 1;
 	}
 
+	if (__le32_to_cpu(super->max_dev) > MAX_DEVS) {
+		if (devname)
+		    pr_err("max_dev (%u) exceeds maximum allowed (%d) in superblock on %s\n",
+			__le32_to_cpu(super->max_dev), MAX_DEVS, devname);
+		free(super);
+		return 2;
+	}
+
 	if (__le32_to_cpu(super->magic) != MD_SB_MAGIC) {
 		if (devname)
 			pr_err("No super block found on %s (Expected magic %08x, got %08x)\n",


### PR DESCRIPTION
Fix this out-of-bounds read vulnerability by validating sb->max_dev immediately after the superblock is loaded in load_super1().

The fix involves checking __le32_to_cpu(super->max_dev) > MAX_DEVS (where MAX_DEVS is (4096 - 256) / 2 = 1920). Rejecting corrupt superblocks at load time prevents out-of-bounds reads across calc_sb_1_csum(), examine_super1(), and getinfo_super1().