### PR TITLE
.gitignore: Add sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /mdassemble.static
 /mdmon.O2
 /raid6check
+
+# Generic untracked directory for logs, scripts etc. for local development.
+sandbox/


### PR DESCRIPTION
Add generic `sandbox` entry to gitignore. Handy for storing logs, scripts, etc. within the codebase context, untracked.